### PR TITLE
Make updates to be spec-compliant to the language server protocol

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,3 @@
 !.eslintrc.js
 **/node_modules/**
-**/VendorLib/**
 **/flow-typed/**
-pkg/nuclide-external-interfaces/1.0/simple-text-buffer.js

--- a/src/cli.js
+++ b/src/cli.js
@@ -17,7 +17,7 @@ const {argv} = yargs
     'GraphQL Language Service Command-Line Interface.\n' +
     'Usage: $0 <command> <file>\n' +
     '    [-h | --help]\n' +
-    '    [-c | --config] {configPath}\n' +
+    '    [-c | --configDir] {configDir}\n' +
     '    [-t | --text] {textBuffer}\n' +
     '    [-f | --file] {filePath}\n' +
     '    [-s | --schema] {schemaPath}\n',
@@ -52,6 +52,14 @@ const {argv} = yargs
       'If omitted, the last column number will be used.\n',
     type: 'number',
   })
+  .option('c', {
+    alias: 'configDir',
+    describe: 'A directory path where .graphqlrc configuration object is\n' +
+      'Walks up the directory tree from the provided config directory, or ' +
+      'the current working directory, until .graphqlrc is found or ' +
+      'the root directory is found.\n',
+    type: 'string',
+  })
   .option('s', {
     alias: 'schemaPath',
     describe: 'a path to schema DSL file\n',
@@ -62,7 +70,7 @@ const command = argv._.pop();
 
 switch (command) {
   case 'server':
-    startServer(argv.config.trim());
+    startServer(argv.configDir);
     break;
   default:
     client(command, argv);

--- a/src/client.js
+++ b/src/client.js
@@ -15,7 +15,7 @@ import fs from 'fs';
 import {buildSchema, buildClientSchema} from 'graphql';
 import path from 'path';
 
-import {Point} from './utils/Range';
+import {Position} from './utils/Range';
 import {
   getAutocompleteSuggestions,
 } from './interfaces/getAutocompleteSuggestions';
@@ -54,7 +54,7 @@ export default function main(command: string, argv: Object): void {
       const lines = text.split('\n');
       const row = argv.row || lines.length - 1;
       const column = argv.column || lines[lines.length - 1].length;
-      const point = new Point(row, column);
+      const point = new Position(row, column);
       exitCode = _getAutocompleteSuggestions(text, point, schemaPath);
       break;
     case 'outline':
@@ -72,7 +72,7 @@ export default function main(command: string, argv: Object): void {
 
 function _getAutocompleteSuggestions(
   queryText: string,
-  point: Point,
+  point: Position,
   schemaPath: string,
 ): EXIT_CODE {
   invariant(
@@ -104,7 +104,7 @@ function _getDiagnostics(
     // `schema` is not strictly requied as GraphQL diagnostics may still notify
     // whether the query text is syntactically valid.
     const schema = schemaPath ? generateSchema(schemaPath) : null;
-    const resultArray = getDiagnostics(filePath, queryText, schema);
+    const resultArray = getDiagnostics(queryText, schema);
     const resultObject = resultArray.reduce((prev, cur, index) => {
       prev[index] = cur;
       return prev;

--- a/src/config/GraphQLConfig.js
+++ b/src/config/GraphQLConfig.js
@@ -17,6 +17,26 @@ const CONFIG_LIST_NAME = 'build-configs';
 const SCHEMA_PATH = 'schema-file';
 const CUSTOM_VALIDATION_RULES_MODULE_PATH = 'custom-validation-rules';
 
+/**
+ * Finds a .graphqlrc configuration file, and returns null if not found.
+ * If the file isn't present in the provided directory path, walk up the
+ * directory tree until the file is found or it reaches the root directory.
+ */
+export async function findGraphQLConfigDir(dirPath: Uri): Promise<?string> {
+  let currentPath = path.resolve(dirPath);
+  let filePath;
+  while (currentPath.length > 1) {
+    filePath = path.join(currentPath, '.graphqlrc');
+    if (fs.existsSync(filePath)) {
+      break;
+    }
+
+    currentPath = path.dirname(currentPath);
+  }
+
+  return filePath ? currentPath : null;
+}
+
 export async function getGraphQLConfig(configDir: Uri): Promise<GraphQLRC> {
   const rawGraphQLConfig = await new Promise((resolve, reject) =>
     fs.readFile(

--- a/src/interfaces/__tests__/getDefinition-test.js
+++ b/src/interfaces/__tests__/getDefinition-test.js
@@ -32,8 +32,8 @@ describe('getDefinition', () => {
         [{file: 'someFile', content: fragment, definition: fragmentDefinition}],
       );
       expect(result.definitions.length).to.equal(1);
-      expect(result.definitions[0].position.row).to.equal(1);
-      expect(result.definitions[0].position.column).to.equal(15);
+      expect(result.definitions[0].position.line).to.equal(1);
+      expect(result.definitions[0].position.character).to.equal(15);
     });
   });
 });

--- a/src/interfaces/__tests__/getDiagnostics-test.js
+++ b/src/interfaces/__tests__/getDiagnostics-test.js
@@ -14,11 +14,8 @@ import {describe, it} from 'mocha';
 import {getDiagnostics} from '../getDiagnostics';
 
 describe('getDiagnostics', () => {
-  const fakePath = require.resolve('../getDiagnostics');
-
   it('catches syntax errors', () => {
-    const error = getDiagnostics(fakePath, 'qeury')[0];
-    expect(error.text).to.contain('Unexpected Name "qeury"');
-    expect(error.filePath).to.equal(fakePath);
+    const error = getDiagnostics('qeury')[0];
+    expect(error.message).to.contain('Unexpected Name "qeury"');
   });
 });

--- a/src/interfaces/autocompleteUtils.js
+++ b/src/interfaces/autocompleteUtils.js
@@ -14,12 +14,11 @@ import type {
   GraphQLType,
 } from 'graphql/type/definition';
 import type {
-  AutocompleteSuggestionType,
+  CompletionItem,
   ContextToken,
   State,
   TypeInfo,
 } from '../types/Types';
-import type {Point} from '../utils/Range';
 
 import {isCompositeType} from 'graphql';
 import {
@@ -98,25 +97,24 @@ export function objectValues(object: Object): Array<any> {
 
 // Create the expected hint response given a possible list and a token
 export function hintList(
-  cursor: Point,
   token: ContextToken,
-  list: Array<AutocompleteSuggestionType>,
-): Array<AutocompleteSuggestionType> {
+  list: Array<CompletionItem>,
+): Array<CompletionItem> {
   return filterAndSortList(list, normalizeText(token.string));
 }
 
 // Given a list of hint entries and currently typed text, sort and filter to
 // provide a concise list.
 function filterAndSortList(
-  list: Array<AutocompleteSuggestionType>,
+  list: Array<CompletionItem>,
   text: string,
-): Array<AutocompleteSuggestionType> {
+): Array<CompletionItem> {
   if (!text) {
     return filterNonEmpty(list, entry => !entry.isDeprecated);
   }
 
   const byProximity = list.map(entry => ({
-    proximity: getProximity(normalizeText(entry.text), text),
+    proximity: getProximity(normalizeText(entry.label), text),
     entry,
   }));
 
@@ -128,7 +126,7 @@ function filterAndSortList(
   const sortedMatches = conciseMatches.sort((a, b) =>
     ((a.entry.isDeprecated ? 1 : 0) - (b.entry.isDeprecated ? 1 : 0)) ||
     (a.proximity - b.proximity) ||
-    (a.entry.text.length - b.entry.text.length),
+    (a.entry.label.length - b.entry.label.length),
   );
 
   return sortedMatches.map(pair => pair.entry);

--- a/src/interfaces/getDefinition.js
+++ b/src/interfaces/getDefinition.js
@@ -19,7 +19,7 @@ import type {
   Uri,
 } from '../types/Types';
 
-import {offsetToPoint, locToRange} from '../utils/Range';
+import {offsetToPosition, locToRange} from '../utils/Range';
 
 export const LANGUAGE = 'GraphQL';
 
@@ -64,7 +64,7 @@ function getDefinitionForFragmentDefinition(
 ): Definition {
   return {
     path,
-    position: offsetToPoint(text, definition.name.loc.start),
+    position: offsetToPosition(text, definition.name.loc.start),
     range: locToRange(text, definition.loc),
     name: definition.name.value,
     language: LANGUAGE,

--- a/src/interfaces/getOutline.js
+++ b/src/interfaces/getOutline.js
@@ -13,7 +13,7 @@ import type {Outline, TextToken, TokenKind} from '../types/Types';
 import {parse, visit} from 'graphql';
 import {INLINE_FRAGMENT} from 'graphql/language/kinds';
 
-import {offsetToPoint} from '../utils/Range';
+import {offsetToPosition} from '../utils/Range';
 
 const OUTLINEABLE_KINDS = {
   Field: true,
@@ -51,8 +51,8 @@ export function getOutline(queryText: string): ?Outline {
 function outlineTreeConverter(docText: string): OutlineTreeConverterType {
   const meta = node => ({
     representativeName: node.name,
-    startPosition: offsetToPoint(docText, node.loc.start),
-    endPosition: offsetToPoint(docText, node.loc.end),
+    startPosition: offsetToPosition(docText, node.loc.start),
+    endPosition: offsetToPosition(docText, node.loc.end),
     children: node.selectionSet || [],
   });
   return {

--- a/src/server/MessageProcessor.js
+++ b/src/server/MessageProcessor.js
@@ -1,0 +1,419 @@
+/**
+ *  Copyright (c) Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @flow
+ */
+
+import type {Diagnostic, Uri} from '../types/Types';
+
+import {getGraphQLCache} from './GraphQLCache';
+
+import {getOutline} from '../interfaces/getOutline';
+import {GraphQLLanguageService} from '../interfaces/GraphQLLanguageService';
+
+import {findGraphQLConfigDir} from '../config/GraphQLConfig';
+
+import {Position} from '../utils/Range';
+
+// Response message error codes
+const ERROR_CODES = {
+  PARSE_ERROR: -32700,
+  INVALID_REQUEST: -32600,
+  METHOD_NOT_FOUND: -32601,
+  INVALID_PARAMS: -32602,
+  INTERNAL_ERROR: -32603,
+  SERVER_ERROR_START: -32099,
+  SERVER_ERROR_END: -32000,
+  SERVER_NOT_INITIALIZED: -32002,
+  UNKNOWN_ERROR_CODE: -32001,
+};
+
+type RequestMessage = {
+  jsonrpc: string,
+  id: number | string,
+  method: string,
+  params?: any,
+};
+
+type ResponseMessage = {
+  jsonrpc: string,
+  id: number | string,
+  result?: any,
+  error?: ResponseError<any>,
+};
+
+type ResponseError<D> = {
+  code: number,
+  message: string,
+  data?: D,
+};
+
+type NotificationMessage = {
+  jsonrpc: string,
+  method: string,
+  params?: any,
+};
+
+type ServerCapabilities = {
+  capabilities: {
+    completionProvider: Object,
+    textDocumentSync: Object | number,
+  },
+};
+
+const REQUEST_IDS_IN_PROGRESS = [];
+
+let graphQLCache;
+let languageService;
+const textDocumentCache: Map<string, Object> = new Map();
+
+export async function processIPCNotificationMessage(
+  message: NotificationMessage,
+): Promise<void> {
+  throw new Error('Not yet implemented.');
+}
+
+export async function processIPCRequestMessage(
+  message: RequestMessage,
+  configDir: ?string,
+): Promise<void> {
+  const method = message.method;
+  let response;
+  let textDocument;
+  switch (method) {
+    case 'initialize':
+      if (!message.params || !message.params.rootPath) {
+        // `rootPath` is required
+        return;
+      }
+      const serverCapabilities = await initialize(
+        configDir ? configDir.trim() : message.params.rootPath,
+      );
+
+      if (serverCapabilities === null) {
+        response = convertToRpcMessage({
+          id: '-1',
+          error: {
+            code: ERROR_CODES.SERVER_NOT_INITIALIZED,
+            message: '.graphqlrc not found',
+          },
+        });
+      } else {
+        response = convertToRpcMessage({
+          id: message.id,
+          result: serverCapabilities,
+        });
+      }
+      sendMessageIPC(response);
+
+      break;
+    case 'textDocument/didOpen':
+    case 'textDocument/didSave':
+      if (!message.params || !message.params.textDocument) {
+        // `textDocument` is required.
+        return;
+      }
+      textDocument = message.params.textDocument;
+      const uri = textDocument.uri;
+
+      let text = textDocument.text;
+      if (!text) {
+        if (textDocumentCache.has(textDocument.uri)) {
+          const cachedDocument = textDocumentCache.get(textDocument.uri);
+          if (cachedDocument) {
+            text = cachedDocument.content.text;
+          }
+        }
+      }
+
+      const diagnostics = await provideDiagnosticsMessage(text, uri);
+      response = convertToRpcMessage({
+        id: message.id,
+        method: 'textDocument/publishDiagnostics',
+        params: {uri, diagnostics},
+      });
+      sendMessageIPC(response);
+      break;
+    case 'textDocument/didChange':
+      // TODO: support onEdit diagnostics
+      // For every `textDocument/didChange` event, keep a cache of textDocuments
+      // with version information up-to-date, so that the textDocument contents
+      // may be used during performing language service features,
+      // e.g. autocompletions.
+      if (
+        !message.params ||
+        !message.params.textDocument ||
+        !message.params.contentChanges
+      ) {
+        // `textDocument` and `contentChanges` are required.
+        return;
+      }
+
+      textDocument = message.params.textDocument;
+      const contentChanges = message.params.contentChanges;
+
+      if (textDocumentCache.has(textDocument.uri)) {
+        const cachedDocument = textDocumentCache.get(textDocument.uri);
+        if (cachedDocument && cachedDocument.version < textDocument.version) {
+          // Current server capabilities specify the full sync of the contents.
+          // Therefore always overwrite the entire content.
+          // Also, as `contentChanges` is an array and we just want the
+          // latest update to the text, grab the last entry from the array.
+          textDocumentCache.set(textDocument.uri, {
+            version: textDocument.version,
+            content: contentChanges[contentChanges.length - 1],
+          });
+        }
+      } else {
+        textDocumentCache.set(textDocument.uri, {
+          version: textDocument.version,
+          content: contentChanges[contentChanges.length - 1],
+        });
+      }
+      break;
+    case 'textDocument/didClose':
+      // For every `textDocument/didClose` event, delete the cached entry.
+      // This is to keep a low memory usage && switch the source of truth to
+      // the file on disk.
+      if (!message.params || !message.params.textDocument) {
+        // `textDocument` is required.
+        return;
+      }
+      textDocument = message.params.textDocument;
+
+      if (textDocumentCache.has(textDocument.uri)) {
+        textDocumentCache.delete(textDocument.uri);
+      }
+      break;
+    case 'textDocument/completion':
+      // `textDocument/comletion` event takes advantage of the fact that
+      // `textDocument/didChange` event always fires before, which would have
+      // updated the cache with the query text from the editor.
+      // Treat the computed list always complete.
+      // (response: Array<CompletionItem>)
+      if (
+        !message.params ||
+        !message.params.textDocument ||
+        !message.params.position
+      ) {
+        // `textDocument` is required.
+        return;
+      }
+      textDocument = message.params.textDocument;
+      const position = message.params.position;
+
+      if (textDocumentCache.has(textDocument.uri)) {
+        const cachedDocument = textDocumentCache.get(textDocument.uri);
+        if (cachedDocument) {
+          const query = cachedDocument.content.text;
+          const result = await languageService.getAutocompleteSuggestions(
+            query,
+            position,
+            textDocument.uri,
+          );
+
+          sendMessageIPC(convertToRpcMessage({
+            id: message.id,
+            result,
+          }));
+        }
+      }
+      break;
+    case '$/cancelRequest':
+      if (!message.params || !message.params.id) {
+        // `id` is required.
+        return;
+      }
+      const requestIDToCancel = message.params.id;
+      const index = REQUEST_IDS_IN_PROGRESS.indexOf(requestIDToCancel);
+      if (index !== -1) {
+        REQUEST_IDS_IN_PROGRESS.splice(index, 1);
+        // A cancelled request still needs to send an empty response back
+        sendMessageIPC({id: requestIDToCancel});
+      }
+      break;
+    case 'shutdown':
+      // prepare to shut down the server
+      break;
+    case 'exit':
+      process.exit(0);
+      break;
+  }
+}
+
+export async function processStreamMessage(
+  message: string,
+  configDir: ?string,
+): Promise<void> {
+  if (message.length === 0) {
+    return;
+  }
+  if (!graphQLCache) {
+    const graphQLConfigDir = await findGraphQLConfigDir(
+      configDir ? configDir.trim() : process.cwd(),
+    );
+    if (!graphQLConfigDir) {
+      process.stdout.write(JSON.stringify(
+        convertToRpcMessage({
+          id: '-1',
+          error: {
+            code: ERROR_CODES.SERVER_NOT_INITIALIZED,
+            message: '.graphqlrc not found',
+          },
+        }),
+      ));
+      return;
+    }
+    graphQLCache = await getGraphQLCache(graphQLConfigDir);
+  }
+  if (!languageService) {
+    languageService = new GraphQLLanguageService(graphQLCache);
+  }
+
+  let json;
+
+  try {
+    json = JSON.parse(message);
+  } catch (error) {
+    process.stdout.write(JSON.stringify(
+      convertToRpcMessage({
+        id: '-1',
+        error: {
+          code: ERROR_CODES.PARSE_ERROR,
+          message: 'Request contains incorrect JSON format',
+        },
+      }),
+    ));
+    return;
+  }
+
+  const id = json.id;
+  const method = json.method;
+
+  let result = null;
+  let responseMsg = null;
+
+  const {query, filePath, position} = json.args;
+
+  switch (method) {
+    case 'disconnect':
+      process.exit(0);
+      break;
+    case 'getDiagnostics':
+      result = await provideDiagnosticsMessage(query, filePath);
+      responseMsg = convertToRpcMessage({
+        type: 'response',
+        id,
+        result,
+      });
+      process.stdout.write(JSON.stringify(responseMsg) + '\n');
+      break;
+    case 'getDefinition':
+      result = await languageService.getDefinition(query, position, filePath);
+      responseMsg = convertToRpcMessage({
+        type: 'response',
+        id,
+        result,
+      });
+      process.stdout.write(JSON.stringify(responseMsg) + '\n');
+      break;
+    case 'getAutocompleteSuggestions':
+      result = await languageService.getAutocompleteSuggestions(
+        query,
+        position,
+        filePath,
+      );
+
+      const formatted = result.map(
+        res => ({
+          text: res.label,
+          typeName: res.detail ? String(res.detail) : null,
+          description: res.documentation || null,
+        }),
+      );
+      responseMsg = convertToRpcMessage({
+        type: 'response',
+        id,
+        formatted,
+      });
+      process.stdout.write(JSON.stringify(responseMsg) + '\n');
+      break;
+    case 'getOutline':
+      result = getOutline(query);
+      responseMsg = convertToRpcMessage({
+        type: 'response',
+        id,
+        result,
+      });
+      process.stdout.write(JSON.stringify(responseMsg) + '\n');
+      break;
+    default:
+      break;
+  }
+}
+
+/**
+ * Helper functions to perform requested services from client/server.
+ */
+
+async function initialize(
+  rootPath: Uri,
+): Promise<?ServerCapabilities> {
+  const serverCapabilities = {
+    capabilities: {
+      completionProvider: {resolveProvider: true},
+      textDocumentSync: 1,
+    },
+  };
+
+  const configDir = await findGraphQLConfigDir(rootPath);
+  if (!configDir) {
+    return null;
+  }
+
+  graphQLCache = await getGraphQLCache(configDir);
+  languageService = new GraphQLLanguageService(graphQLCache);
+
+  return serverCapabilities;
+}
+
+async function provideDiagnosticsMessage(
+  query: string,
+  uri: Uri,
+): Promise<Array<Diagnostic>> {
+  let results = await languageService.getDiagnostics(query, uri);
+  if (results && results.length > 0) {
+    const queryLines = query.split('\n');
+    const totalLines = queryLines.length;
+    const lastLineLength = queryLines[totalLines - 1].length;
+    const lastCharacterPosition = new Position(totalLines, lastLineLength);
+    results = results.filter(diagnostic =>
+      diagnostic.range.end.lessThanOrEqualTo(lastCharacterPosition),
+    );
+  }
+
+  return results;
+}
+
+function sendMessageIPC(message: any): void {
+  if (process.send !== undefined) {
+    process.send(message);
+  }
+}
+
+/**
+ * Composes a language server protocol JSON message.
+ */
+function convertToRpcMessage(metaMessage: Object): ResponseMessage {
+  const message: ResponseMessage = {
+    jsonrpc: '2.0',
+    protocol: 'graphql_language_service',
+    ...metaMessage,
+  };
+
+  return message;
+}

--- a/src/types/Types.js
+++ b/src/types/Types.js
@@ -17,7 +17,7 @@ import type {
   GraphQLType,
 } from 'graphql/type/definition';
 import type CharacterStream from '../parser/CharacterStream';
-import type {Point, Range} from '../utils/Range';
+import type {Position, Range} from '../utils/Range';
 
 // online-parser related
 export type ParseRule =
@@ -96,28 +96,30 @@ export type FragmentInfo = {
 
 export type CustomValidationRule = (context: ValidationContext) => Object;
 
-export type DiagnosticType = {
-  name: string,
-  type: string,
-  text: string,
+export type Diagnostic = {
   range: Range,
-  filePath: Uri,
+  severity?: number,
+  code?: number | string,
+  source?: string,
+  message: string,
 };
 
-export type AutocompleteSuggestionType = {
-  text: string,
-  type?: GraphQLType,
-  description?: ?string,
+export type CompletionItem = {
+  label: string,
+  kind?: number,
+  detail?: string,
+  documentation?: string,
+  // GraphQL Deprecation information
   isDeprecated?: ?string,
   deprecationReason?: ?string,
 };
 
 // Below are basically a copy-paste from Nuclide rpc types for definitions.
-//
+
 // Definitions/hyperlink
 export type Definition = {
   path: Uri,
-  position: Point,
+  position: Position,
   range?: Range,
   id?: string,
   name?: string,
@@ -151,8 +153,8 @@ export type OutlineTree = {
   tokenizedText?: TokenizedText,
   representativeName?: string,
 
-  startPosition: Point,
-  endPosition?: Point,
+  startPosition: Position,
+  endPosition?: Position,
   children: Array<OutlineTree>,
 };
 export type Outline = {

--- a/src/utils/Range.js
+++ b/src/utils/Range.js
@@ -11,34 +11,35 @@
 import type {Location} from 'graphql/language';
 
 export class Range {
-  start: Point;
-  end: Point;
-  constructor(start: Point, end: Point): void {
+  start: Position;
+  end: Position;
+  constructor(start: Position, end: Position): void {
     this.start = start;
     this.end = end;
   }
 
-  containsPoint(point: Point): boolean {
-    const withinRow =
-      this.start.row <= point.row && this.end.row >= point.row;
-    const withinColumn =
-      this.start.column <= point.column && this.end.column >= point.column;
-    return withinRow && withinColumn;
+  containsPosition(position: Position): boolean {
+    const withinLine =
+      this.start.line <= position.line && this.end.line >= position.line;
+    const withinCharacter =
+      this.start.character <= position.character &&
+      this.end.character >= position.character;
+    return withinLine && withinCharacter;
   }
 }
 
-export class Point {
-  row: number;
-  column: number;
-  constructor(row: number, column: number): void {
-    this.row = row;
-    this.column = column;
+export class Position {
+  line: number;
+  character: number;
+  constructor(line: number, character: number): void {
+    this.line = line;
+    this.character = character;
   }
 
-  lessThanOrEqualTo(point: Point): boolean {
+  lessThanOrEqualTo(position: Position): boolean {
     if (
-      this.row < point.row ||
-      (this.row === point.row && this.column <= point.column)
+      this.line < position.line ||
+      (this.line === position.line && this.character <= position.character)
     ) {
       return true;
     }
@@ -47,16 +48,16 @@ export class Point {
   }
 }
 
-export function offsetToPoint(text: string, loc: number): Point {
+export function offsetToPosition(text: string, loc: number): Position {
   const EOL = '\n';
   const buf = text.slice(0, loc);
-  const rows = buf.split(EOL).length - 1;
+  const lines = buf.split(EOL).length - 1;
   const lastLineIndex = buf.lastIndexOf(EOL);
-  return new Point(rows, loc - lastLineIndex - 1);
+  return new Position(lines, loc - lastLineIndex - 1);
 }
 
 export function locToRange(text: string, loc: Location): Range {
-  const start = offsetToPoint(text, loc.start);
-  const end = offsetToPoint(text, loc.end);
+  const start = offsetToPosition(text, loc.start);
+  const end = offsetToPosition(text, loc.end);
   return new Range(start, end);
 }

--- a/src/utils/__tests__/getASTNodeAtPosition-test.js
+++ b/src/utils/__tests__/getASTNodeAtPosition-test.js
@@ -12,8 +12,8 @@ import {expect} from 'chai';
 import {parse} from 'graphql';
 import {describe, it} from 'mocha';
 
-import {Point} from '../Range';
-import {getASTNodeAtPoint, pointToOffset} from '../getASTNodeAtPoint';
+import {Position} from '../Range';
+import {getASTNodeAtPosition, pointToOffset} from '../getASTNodeAtPosition';
 
 const doc = `
 query A {
@@ -26,10 +26,10 @@ fragment B on B {
 
 const ast = parse(doc);
 
-describe('getASTNodeAtPoint', () => {
+describe('getASTNodeAtPosition', () => {
   it('gets the node at the beginning', () => {
-    const point = new Point(2, 0);
-    const node = getASTNodeAtPoint(doc, ast, point);
+    const point = new Position(2, 0);
+    const node = getASTNodeAtPosition(doc, ast, point);
     expect(node).to.not.be.undefined;
     if (node != null) {
       expect(node.name.value).to.equal('field');
@@ -37,8 +37,8 @@ describe('getASTNodeAtPoint', () => {
   });
 
   it('does not find the node before the beginning', () => {
-    const point = new Point(0, 0);
-    const node = getASTNodeAtPoint(doc, ast, point);
+    const point = new Position(0, 0);
+    const node = getASTNodeAtPosition(doc, ast, point);
     expect(node).to.not.be.undefined;
     if (node != null) {
       expect(node.kind).to.equal('Document');
@@ -46,8 +46,8 @@ describe('getASTNodeAtPoint', () => {
   });
 
   it('gets the node at the end', () => {
-    const point = new Point(2, 5);
-    const node = getASTNodeAtPoint(doc, ast, point);
+    const point = new Position(2, 5);
+    const node = getASTNodeAtPosition(doc, ast, point);
     expect(node).to.not.be.undefined;
     if (node != null) {
       expect(node.name.value).to.equal('field');
@@ -55,8 +55,8 @@ describe('getASTNodeAtPoint', () => {
   });
 
   it('does not find the node after the end', () => {
-    const point = new Point(4, 0);
-    const node = getASTNodeAtPoint(doc, ast, point);
+    const point = new Position(4, 0);
+    const node = getASTNodeAtPosition(doc, ast, point);
     expect(node).to.not.be.undefined;
     if (node != null) {
       expect(node.kind).to.equal('Document');
@@ -67,13 +67,13 @@ describe('getASTNodeAtPoint', () => {
 describe('pointToOffset', () => {
   it('works for single lines', () => {
     const text = 'lorem';
-    expect(pointToOffset(text, new Point(0, 2))).to.equal(2);
+    expect(pointToOffset(text, new Position(0, 2))).to.equal(2);
   });
 
   it('takes EOL into account', () => {
     const text = 'lorem\n';
     expect(
-      pointToOffset(text, new Point(1, 0)),
+      pointToOffset(text, new Position(1, 0)),
     ).to.equal(
       text.length,
     );

--- a/src/utils/getASTNodeAtPosition.js
+++ b/src/utils/getASTNodeAtPosition.js
@@ -10,23 +10,23 @@
 
 import type {ASTNode} from 'graphql/language';
 
-import {Point} from './Range';
+import {Position} from './Range';
 import {visit} from 'graphql';
 
-export function getASTNodeAtPoint(
+export function getASTNodeAtPosition(
   query: string,
   ast: ASTNode,
-  point: Point,
+  point: Position,
 ): ?ASTNode {
   const offset = pointToOffset(query, point);
-  let nodeContainingPoint: ?ASTNode;
+  let nodeContainingPosition: ?ASTNode;
   visit(ast, {
     enter(node) {
       if (
         node.kind !== 'Name' && // We're usually interested in their parents
         node.loc.start <= offset && offset <= node.loc.end
       ) {
-        nodeContainingPoint = node;
+        nodeContainingPosition = node;
       } else {
         return false;
       }
@@ -37,12 +37,12 @@ export function getASTNodeAtPoint(
       }
     },
   });
-  return nodeContainingPoint;
+  return nodeContainingPosition;
 }
 
-export function pointToOffset(text: string, point: Point): number {
-  const linesUntilPoint = text.split('\n').slice(0, point.row);
-  return point.column + linesUntilPoint.map(line =>
+export function pointToOffset(text: string, point: Position): number {
+  const linesUntilPosition = text.split('\n').slice(0, point.line);
+  return point.character + linesUntilPosition.map(line =>
     line.length + 1, // count EOL
   ).reduce((a, b) => a + b, 0);
 }


### PR DESCRIPTION
closes #6.

Inspired by [the language server protocol](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md), this PR adds supports to match the mentioned protocol specifications. Notable changes are:

* New:
  - Adds methods to be invoked from the client using IPC protocol
    - File events (`didOpen`, `didClose`, `didSave`, `didChange`)
    - Implemented GraphQL diagnostics and autocomplete suggestions (`textDocument/publishDiagnostics` and `textDocument/completion`)
  - Added a way to find `.graphqlrc` configuration file
  - Added support to IPC transport communication (`src/server/MessageProcessor.js`)
    - Added support to VSCode client
* Changes/fixes:
  - Changed related flow types and type references to match the protocol spec
  - Updated `README` to match the current implementations