### PR TITLE
Declare new Range and Position interfaces

### DIFF
--- a/src/types/Types.js
+++ b/src/types/Types.js
@@ -17,9 +17,20 @@ import type {
   GraphQLType,
 } from 'graphql/type/definition';
 import type CharacterStream from '../parser/CharacterStream';
-import type {Position, Range} from '../utils/Range';
 
 // online-parser related
+export interface Position {
+  line: number,
+  character: number,
+  lessThanOrEqualTo: (position: Position) => boolean,
+}
+
+export interface Range {
+  start: Position,
+  end: Position,
+  containsPosition: (position: Position) => boolean,
+}
+
 export type ParseRule =
   ((token: Token, stream: CharacterStream) => ?string) |
   Array<Rule | string>;

--- a/src/utils/Range.js
+++ b/src/utils/Range.js
@@ -40,16 +40,10 @@ export class Position implements PositionInterface {
     this.character = character;
   }
 
-  lessThanOrEqualTo = (position: PositionInterface): boolean => {
-    if (
-      this.line < position.line ||
-      (this.line === position.line && this.character <= position.character)
-    ) {
-      return true;
-    }
-
-    return false;
-  }
+  lessThanOrEqualTo = (position: PositionInterface): boolean => (
+    this.line < position.line ||
+    (this.line === position.line && this.character <= position.character)
+  );
 }
 
 export function offsetToPosition(text: string, loc: number): Position {

--- a/src/utils/Range.js
+++ b/src/utils/Range.js
@@ -9,16 +9,20 @@
  */
 
 import type {Location} from 'graphql/language';
+import type {
+  Range as RangeInterface,
+  Position as PositionInterface,
+} from '../types/Types';
 
-export class Range {
-  start: Position;
-  end: Position;
-  constructor(start: Position, end: Position): void {
+export class Range implements RangeInterface {
+  start: PositionInterface;
+  end: PositionInterface;
+  constructor(start: PositionInterface, end: PositionInterface): void {
     this.start = start;
     this.end = end;
   }
 
-  containsPosition(position: Position): boolean {
+  containsPosition = (position: PositionInterface): boolean => {
     const withinLine =
       this.start.line <= position.line && this.end.line >= position.line;
     const withinCharacter =
@@ -28,7 +32,7 @@ export class Range {
   }
 }
 
-export class Position {
+export class Position implements PositionInterface {
   line: number;
   character: number;
   constructor(line: number, character: number): void {
@@ -36,7 +40,7 @@ export class Position {
     this.character = character;
   }
 
-  lessThanOrEqualTo(position: Position): boolean {
+  lessThanOrEqualTo = (position: PositionInterface): boolean => {
     if (
       this.line < position.line ||
       (this.line === position.line && this.character <= position.character)


### PR DESCRIPTION
This is the first step in breaking some circular type dependencies that we have which are preventing us from breaking the language service into separate packages. The goal here is to move all shared types into the types module, which should itself have no dependencies on anything inside the language service.

- Declare `Range` and `Position` as interfaces.
- Annotate that the `Range` and `Position` classes implement the interfaces.
- Switch to property assignment syntax so that Flow won't complain about covariance vs invariance.
