### PR TITLE
Add some build utils to "types" package

### DIFF
--- a/packages/graphql-language-service-types/package.json
+++ b/packages/graphql-language-service-types/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "test": "npm run lint && npm run check",
     "lint": "eslint src || (printf '\\033[33mTry: \\033[7m npm run lint -- --fix \\033[0m\\n' && exit 1)",
-    "build": "babel src --out-dir dist/ && cp package.json dist/",
+    "build": "npm run build-js && npm run build-flow",
+    "build-js": "babel-node scripts/build-js.js",
     "build-flow": "babel-node scripts/build-flow.js",
     "check": "flow check"
   },

--- a/packages/graphql-language-service-types/scripts/build-flow.js
+++ b/packages/graphql-language-service-types/scripts/build-flow.js
@@ -8,16 +8,13 @@
 
 'use strict';
 
-import {
-  createReadStream,
-  createWriteStream,
-  readdirSync,
-} from 'fs';
+import {readdirSync} from 'fs';
 import {join} from 'path';
+import {cp} from './util';
 
 // Non-recursively copy src/*.js to dist/*.js.flow:
 readdirSync('src').forEach(entry => {
-  const src = join('src', entry);
-  const dest = join('dist', `${entry}.flow`);
-  createReadStream(src).pipe(createWriteStream(dest));
+  const source = join('src', entry);
+  const destination = join('dist', `${entry}.flow`);
+  cp(source, destination);
 });

--- a/packages/graphql-language-service-types/scripts/build-js.js
+++ b/packages/graphql-language-service-types/scripts/build-js.js
@@ -1,0 +1,15 @@
+/**
+ *  Copyright (c) Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import {join} from 'path';
+import {cp, exec} from './util';
+
+exec('babel', 'src', '--out-dir', 'dist');
+cp('package.json', join('dist', 'package.json'));

--- a/packages/graphql-language-service-types/scripts/util.js
+++ b/packages/graphql-language-service-types/scripts/util.js
@@ -1,0 +1,20 @@
+/**
+ *  Copyright (c) Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @flow
+ */
+
+'use strict';
+
+import {
+  createReadStream,
+  createWriteStream,
+} from 'fs';
+
+export function cp(source: string, destination: string): void {
+  createReadStream(source).pipe(createWriteStream(destination));
+}

--- a/packages/graphql-language-service-types/scripts/util.js
+++ b/packages/graphql-language-service-types/scripts/util.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import {execFileSync} from 'child_process';
 import {
   createReadStream,
   createWriteStream,
@@ -17,4 +18,12 @@ import {
 
 export function cp(source: string, destination: string): void {
   createReadStream(source).pipe(createWriteStream(destination));
+}
+
+export function exec(executable: string, ...args: string[]): void {
+  print(execFileSync(executable, args).toString());
+}
+
+export function print(string: string): void {
+  process.stdout.write(string);
 }


### PR DESCRIPTION
Going to cut a first experimental release of this, so making some helper tools before I do. Primarily, want to make sure that we get the `.flow` file in the published package — otherwise the entire purpose of the package is defeated — so that means baking it into the `npm run build` process.