### PR TITLE
Hoist some more types up into "types" package

### DIFF
--- a/packages/graphql-language-service-types/package.json
+++ b/packages/graphql-language-service-types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graphql-language-service-types",
   "repository": "https://github.com/graphql/graphql-language-service",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Types for building GraphQL language services for IDEs",
   "contributors": [
     "Greg Hurrell <greg@hurrell.net> (https://greg.hurrell.net/)",

--- a/packages/graphql-language-service-types/src/index.js
+++ b/packages/graphql-language-service-types/src/index.js
@@ -8,6 +8,7 @@
  *  @flow
  */
 
+import type {GraphQLSchema} from 'graphql';
 import type {ASTNode, FragmentDefinitionNode} from 'graphql/language';
 import type {ValidationContext} from 'graphql/validation';
 import type {
@@ -43,6 +44,45 @@ export interface CharacterStream {
   column: () => number,
   indentation: () => number,
   current: () => string,
+}
+
+// Cache and config-related.
+export interface GraphQLRC {
+  getConfigDir: () => Uri,
+  getConfigNames: () => Array<string>,
+  getConfig: (name: string) => GraphQLConfig,
+  getConfigByFilePath: (filePath: Uri) => ?GraphQLConfig,
+}
+
+export interface GraphQLConfig {
+  getRootDir: () => Uri,
+  getName: () => string,
+  getConfig: () => Object,
+  getInputDirs: () => Array<string>,
+  getExcludeDirs: () => Array<string>,
+  isFileInInputDirs: (fileName: string) => boolean,
+  getSchemaPath: () => ?Uri,
+  getCustomValidationRulesModulePath: () => ?Uri,
+}
+
+export interface GraphQLCache {
+  getGraphQLRC: () => GraphQLRC,
+
+  getFragmentDependencies: (
+    query: string,
+    fragmentDefinitions: ?Map<string, FragmentInfo>,
+  ) => Promise<Array<FragmentInfo>>,
+
+  getFragmentDependenciesForAST: (
+    parsedQuery: ASTNode,
+    fragmentDefinitions: Map<string, FragmentInfo>,
+  ) => Promise<Array<FragmentInfo>>,
+
+  getFragmentDefinitions: (
+    graphQLConfig: GraphQLConfig,
+  ) => Promise<Map<string, FragmentInfo>>,
+
+  getSchema: (configSchemaPath: ?Uri) => Promise<?GraphQLSchema>
 }
 
 // online-parser related


### PR DESCRIPTION
Want to break circular dependency of "interface" on "server". ("server" depends on "interface", but "interface" depends on a type in "server".)

Specifically, "interface" depends on GraphQLCache, which depends on GraphQLRC, which depends on GraphQLConfig, so all three get hoisted up.