### PR TITLE
Add .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Hyohyeon Jeong <asiandrummer@fb.com> Hyo Jeong <asiandrummer@users.noreply.github.com>
+Greenkeeper <support@greenkeeper.io> greenkeeperio-bot <support@greenkeeper.io>


### PR DESCRIPTION
Cleans up duplicate entries from `git shortlog` output. For example,
these entries:

     5	Greenkeeper
    10	Hyo Jeong
    20	Hyohyeon Jeong
    17	greenkeeperio-bot

Get consolidated to:

    22	Greenkeeper
    30	Hyohyeon Jeong