### PR TITLE
Suppress lint

### DIFF
--- a/packages/graphql-language-service-server/src/GraphQLCache.js
+++ b/packages/graphql-language-service-server/src/GraphQLCache.js
@@ -391,7 +391,7 @@ async function readAllGraphQLFiles(
             mtime: fileInfo.mtime,
             size: fileInfo.size,
           })));
-    await Promise.all(promises); // eslint-disable-line no-await-in-loop
+    await Promise.all(promises); // eslint-disable-line babel/no-await-in-loop
   }
 
   return processGraphQLFiles(responses);


### PR DESCRIPTION
We were trying to suppress this, but the suppression wasn't working:

> warning Avoid using await inside a loop. Consider refactoring to use Promise.all. If you are sure you want to do this, add `// eslint-disable-line babel/no-await-in-loop` at the end of this line babel/no-await-in-loop

Tweak the suppression a little to make it actually work.