### PR TITLE
Replace inaccurate comment

### DIFF
--- a/packages/graphql-language-service-server/src/startServer.js
+++ b/packages/graphql-language-service-server/src/startServer.js
@@ -45,8 +45,7 @@ export default (async function startServer(
           processIPCNotificationMessage(message, messageWriter);
         }
       } catch (error) {
-        // Return with error message
-        return;
+        // Swallow error silently.
       }
     });
   }


### PR DESCRIPTION
As mentioned in review of https://github.com/graphql/graphql-language-service/pull/92, we're not actually doing anything with the error message here (perhaps we should, but that is another topic). Adjust the comment to reflect reality.