### PR TITLE
Update to latest Flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "eslint-plugin-dependencies": "2.0.0",
     "eslint-plugin-flowtype": "2.30.4",
     "eslint-plugin-prefer-object-spread": "1.1.0",
-    "flow-bin": "0.42.0",
+    "flow-bin": "0.43.0",
     "mocha": "3.2.0",
     "prettier": "^0.22.0"
   }


### PR DESCRIPTION
0.43.0 is a tiny bit smarter, so reports only 112 Flow errors.