### PR TITLE
Bump version on graphql-language-server package

### DIFF
--- a/packages/graphql-language-server/package.json
+++ b/packages/graphql-language-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-language-server",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "An interface for building GraphQL language services for IDEs",
   "scripts": {
     "test": "echo 'Please run `npm test` from the root of the repo' && exit 1"
@@ -18,6 +18,6 @@
   },
   "homepage": "https://github.com/graphql/graphql-language-service#readme",
   "dependencies": {
-    "graphql-language-service": "0.0.2"
+    "graphql-language-service": "0.0.22"
   }
 }


### PR DESCRIPTION
Had to do this manually, which suggests we should update the `bumpVersions` script to do it automatically for us.