### PR TITLE
Manually sync versions.json file

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -3,7 +3,7 @@
     "version": "0.0.22"
   },
   "graphql-language-server": {
-    "version": "0.0.2"
+    "version": "0.0.3"
   },
   "graphql-language-service-config": {
     "version": "0.0.14"


### PR DESCRIPTION
Seeing as I had to manually bump the graphql-language-server version.

Did a manual test of `bumpVersion.js` after this to confirm that it correctly updates this package version when the dependencies change (it does), so I think we'll remain in sync from here on.