### PR TITLE
Silence an eslint deprecation warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -85,6 +85,7 @@ module.exports = {
     'eqeqeq': [1, 'allow-null'],
     'guard-for-in': 0,
     'no-alert': 1,
+    'no-await-in-loop': 1,
     'no-caller': 1,
     'no-case-declarations': 0,
     'no-div-regex': 1,
@@ -291,8 +292,6 @@ module.exports = {
     'babel/new-cap': 0,
     'babel/no-invalid-this': 0,
     'babel/object-curly-spacing': 0,
-    // Babel (not in eslint)
-    'babel/no-await-in-loop': 1,
 
     // dependencies (https://github.com/zertosh/eslint-plugin-dependencies)
     'dependencies/case-sensitive': 1,

--- a/packages/server/src/GraphQLCache.js
+++ b/packages/server/src/GraphQLCache.js
@@ -445,7 +445,7 @@ export class GraphQLCache {
             }),
           ),
       );
-      await Promise.all(promises); // eslint-disable-line babel/no-await-in-loop
+      await Promise.all(promises); // eslint-disable-line no-await-in-loop
     }
 
     return this.processGraphQLFiles(responses);


### PR DESCRIPTION
Silences:

    The babel/no-await-in-loop rule is deprecated. Please use the built in no-await-in-loop rule instead.

Noticed this while looking at: https://travis-ci.org/graphql/graphql-language-service/builds/265054808