### PR TITLE
Recognize gql-tagged queries

### DIFF
--- a/packages/server/src/MessageProcessor.js
+++ b/packages/server/src/MessageProcessor.js
@@ -487,6 +487,7 @@ export function getQueryAndRange(
   if (extname(uri) === '.js') {
     if (
       text.indexOf('graphql`') === -1 &&
+      text.indexOf('gql`') === -1 &&
       text.indexOf('graphql.experimental`') === -1
     ) {
       return [];

--- a/packages/server/src/__tests__/MessageProcessor-test.js
+++ b/packages/server/src/__tests__/MessageProcessor-test.js
@@ -12,7 +12,7 @@ import {expect} from 'chai';
 import {Position, Range} from 'graphql-language-service-utils';
 import {beforeEach, describe, it} from 'mocha';
 
-import {MessageProcessor} from '../MessageProcessor';
+import {getQueryAndRange, MessageProcessor} from '../MessageProcessor';
 
 describe('MessageProcessor', () => {
   const messageProcessor = new MessageProcessor();
@@ -163,5 +163,21 @@ describe('MessageProcessor', () => {
 
     const result = await messageProcessor.handleDefinitionRequest(test);
     expect(result[0].uri).to.equal(`file://${queryDir}/testFragment.graphql`);
+  });
+});
+
+describe('MessageProcessor.getQueryAndRange', () => {
+  it('finds tagged queries in js', () => {
+    const content = `
+      graphql\`query graphql { id }\`;
+      graphql.experimental\`query graphql_experimental { id }\`;
+      gql\`query gql { id }\`;
+    `;
+    const queries = getQueryAndRange(content, 'file.js').map(x => x.query);
+    expect(queries).to.deep.equal([
+      'query graphql { id }',
+      'query graphql_experimental { id }',
+      'query gql { id }',
+    ]);
   });
 });

--- a/packages/server/src/findGraphQLTags.js
+++ b/packages/server/src/findGraphQLTags.js
@@ -63,7 +63,11 @@ export function findGraphQLTags(
         fragments.properties.forEach(property => {
           const tagName = getGraphQLTagName(property.value.tag);
           const template = getGraphQLText(property.value.quasi);
-          if (tagName === 'graphql' || tagName === 'graphql.experimental') {
+          if (
+            tagName === 'graphql' ||
+            tagName === 'gql' ||
+            tagName === 'graphql.experimental'
+          ) {
             const loc = property.value.loc;
             const range = new Range(
               new Position(loc.start.line - 1, loc.start.column),
@@ -79,7 +83,11 @@ export function findGraphQLTags(
       } else {
         const tagName = getGraphQLTagName(fragments.tag);
         const template = getGraphQLText(fragments.quasi);
-        if (tagName === 'graphql' || tagName === 'graphql.experimental') {
+        if (
+          tagName === 'graphql' ||
+          tagName === 'gql' ||
+          tagName === 'graphql.experimental'
+        ) {
           const loc = fragments.loc;
           const range = new Range(
             new Position(loc.start.line - 1, loc.start.column),
@@ -101,7 +109,11 @@ export function findGraphQLTags(
     TaggedTemplateExpression: node => {
       const tagName = getGraphQLTagName(node.tag);
       if (tagName != null) {
-        if (tagName === 'graphql' || tagName === 'graphql.experimental') {
+        if (
+          tagName === 'graphql' ||
+          tagName === 'gql' ||
+          tagName === 'graphql.experimental'
+        ) {
           const loc = node.quasi.quasis[0].loc;
           const range = new Range(
             new Position(loc.start.line - 1, loc.start.column),
@@ -126,7 +138,7 @@ const CREATE_CONTAINER_FUNCTIONS = {
   createRefetchContainer: true,
 };
 
-const IDENTIFIERS = {graphql: true};
+const IDENTIFIERS = {graphql: true, gql: true};
 
 const IGNORED_KEYS = {
   comments: true,


### PR DESCRIPTION
Apollo client uses tag `gql` for inline queries:

```js
import {gql} from 'react-apollo';

gql`
  query { field }
`;
```

Would be nice if graphql-language-service recognized this tag too.