### PR TITLE
lsp: textDocument/documentSymbol support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "javascript.validate.enable": false
+}

--- a/README.md
+++ b/README.md
@@ -116,6 +116,6 @@ For each transport, there is a slight difference in JSON message format, especia
 | -------------------:|------------------------------|-----------------------------------|
 | Diagnostics         | `getDiagnostics`             | `textDocument/publishDiagnostics` |
 | Autocompletion      | `getAutocompleteSuggestions` | `textDocument/completion`         |
-| Outline             | `getOutline`                 | Not supported yet                 |
+| Outline             | `getOutline`                 | `textDocument/documentSymbol`     |
 | Go-to definition    | `getDefinition`              | Not supported yet                 |
 | File Events         | Not supported yet            | `didOpen/didClose/didSave/didChange` events |

--- a/packages/interface/src/GraphQLLanguageService.js
+++ b/packages/interface/src/GraphQLLanguageService.js
@@ -21,6 +21,7 @@ import type {
   GraphQLCache,
   GraphQLConfig,
   GraphQLProjectConfig,
+  Outline,
   Uri,
 } from 'graphql-language-service-types';
 import type {Position} from 'graphql-language-service-utils';
@@ -46,6 +47,7 @@ import {
   getDefinitionQueryResultForFragmentSpread,
   getDefinitionQueryResultForDefinitionNode,
 } from './getDefinition';
+import {getOutline} from './getOutline';
 import {getASTNodeAtPosition} from 'graphql-language-service-utils';
 
 export class GraphQLLanguageService {
@@ -243,5 +245,9 @@ export class GraphQLLanguageService {
     );
 
     return result;
+  }
+
+  async getOutline(query: string): Promise<?Outline> {
+    return getOutline(query);
   }
 }

--- a/packages/interface/src/getOutline.js
+++ b/packages/interface/src/getOutline.js
@@ -56,6 +56,7 @@ function outlineTreeConverter(docText: string): OutlineTreeConverterType {
     representativeName: node.name,
     startPosition: offsetToPosition(docText, node.loc.start),
     endPosition: offsetToPosition(docText, node.loc.end),
+    kind: node.kind,
     children: node.selectionSet || [],
   });
   return {

--- a/packages/server/src/startServer.js
+++ b/packages/server/src/startServer.js
@@ -34,6 +34,7 @@ import {
   ExitNotification,
   InitializeRequest,
   PublishDiagnosticsNotification,
+  DocumentSymbolRequest,
   ShutdownRequest,
 } from 'vscode-languageserver';
 
@@ -167,5 +168,8 @@ function addHandlers(
   connection.onRequest(CompletionResolveRequest.type, item => item);
   connection.onRequest(DefinitionRequest.type, params =>
     messageProcessor.handleDefinitionRequest(params),
+  );
+  connection.onRequest(DocumentSymbolRequest.type, (params, token) =>
+    messageProcessor.handleDocumentSymbolRequest(params),
   );
 }

--- a/packages/types/src/index.js
+++ b/packages/types/src/index.js
@@ -259,6 +259,7 @@ export type OutlineTree = {
   tokenizedText?: TokenizedText,
   representativeName?: string,
 
+  kind: string,
   startPosition: Position,
   endPosition?: Position,
   children: Array<OutlineTree>,


### PR DESCRIPTION
This PR adds support for `textDocument/documentSymbol` to the lsp-compatible server.

Here's a screenshot in vscode:
![outline](https://user-images.githubusercontent.com/2320890/34366465-83542b54-ea61-11e7-8cbd-7ebef5cb6049.gif)
