### PR TITLE
Fixes #223 - handle case when .graphqlconfig defines projects

### DIFF
--- a/packages/server/src/MessageProcessor.js
+++ b/packages/server/src/MessageProcessor.js
@@ -149,7 +149,7 @@ export class MessageProcessor {
       // Otherwise, subcribe watchman according to project config(s).
       const config = getGraphQLConfig(rootPath);
       let projectConfigs: GraphQLProjectConfig[] =
-        Object.values(config.getProjects()) || [];
+        Object.values(config.getProjects() || {}) || [];
       // There can either be a single config or one or more project
       // configs, but not both.
       if (projectConfigs.length === 0) {


### PR DESCRIPTION
In addition to fix the issue details in #223, this patch also addresses the errors we were seeing in the console this morning:

```
(node:4595) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): TypeError: Cannot convert undefined or null to object
(node:4595) DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

The above unhandled error was raised by invoking `Object.values(undefined)` in `MessageProcessor.js` in the case where a `.graphqlconfig` file defined project-level settings.