### PR TITLE
fix: add ExecutableDefinitions to ignored rules for validation

### DIFF
--- a/packages/utils/src/validateWithCustomRules.js
+++ b/packages/utils/src/validateWithCustomRules.js
@@ -30,7 +30,10 @@ export function validateWithCustomRules(
   const {
     NoUnusedFragments,
   } = require('graphql/validation/rules/NoUnusedFragments');
-  const rulesToSkip = [NoUnusedFragments];
+  const {
+    ExecutableDefinitions,
+  } = require('graphql/validation/rules/ExecutableDefinitions');
+  const rulesToSkip = [NoUnusedFragments, ExecutableDefinitions];
   if (isRelayCompatMode) {
     const {
       KnownFragmentNames,


### PR DESCRIPTION
1. Add ExecutableDefinitions to ignored rules for schema validation