### PR TITLE
Fix build: bump prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,6 @@
     "graphql-language-service-utils": "^1.0.0-0",
     "lerna": "^2.0.0",
     "mocha": "4.1.0",
-    "prettier": "^1.5.3"
+    "prettier": "1.13"
   }
 }

--- a/packages/interface/src/getAutocompleteSuggestions.js
+++ b/packages/interface/src/getAutocompleteSuggestions.js
@@ -304,8 +304,9 @@ function getSuggestionsForFragmentSpread(
     relevantFrags.map(frag => ({
       label: frag.name.value,
       detail: String(typeMap[frag.typeCondition.name.value]),
-      documentation: `fragment ${frag.name.value} on ${frag.typeCondition.name
-        .value}`,
+      documentation: `fragment ${frag.name.value} on ${
+        frag.typeCondition.name.value
+      }`,
     })),
   );
 }

--- a/packages/interface/src/getDefinition.js
+++ b/packages/interface/src/getDefinition.js
@@ -52,10 +52,9 @@ export async function getDefinitionQueryResultForFragmentSpread(
     process.stderr.write(`Definition not found for GraphQL fragment ${name}`);
     return {queryRange: [], definitions: []};
   }
-  const definitions: Array<
-    Definition,
-  > = defNodes.map(({filePath, content, definition}) =>
-    getDefinitionForFragmentDefinition(filePath || '', content, definition),
+  const definitions: Array<Definition> = defNodes.map(
+    ({filePath, content, definition}) =>
+      getDefinitionForFragmentDefinition(filePath || '', content, definition),
   );
   return {
     definitions,

--- a/packages/interface/src/getDiagnostics.js
+++ b/packages/interface/src/getDiagnostics.js
@@ -106,7 +106,9 @@ function annotations(
     const highlightNode =
       node.kind !== 'Variable' && node.name
         ? node.name
-        : node.variable ? node.variable : node;
+        : node.variable
+          ? node.variable
+          : node;
 
     invariant(error.locations, 'GraphQL validation error requires locations.');
     const loc = error.locations[0];

--- a/packages/parser/src/Rules.js
+++ b/packages/parser/src/Rules.js
@@ -18,8 +18,8 @@ import type {
 import {opt, list, butNot, t, p} from './RuleHelpers';
 
 /**
-  * Whitespace tokens defined in GraphQL spec.
-  */
+ * Whitespace tokens defined in GraphQL spec.
+ */
 export const isIgnored = (ch: string) =>
   ch === ' ' ||
   ch === '\t' ||
@@ -120,7 +120,9 @@ export const ParseRules: {[name: string]: ParseRule} = {
       ? stream.match(/[\s\u00a0,]*(on\b|@|{)/, false)
         ? 'InlineFragment'
         : 'FragmentSpread'
-      : stream.match(/[\s\u00a0,]*:/, false) ? 'AliasedField' : 'Field';
+      : stream.match(/[\s\u00a0,]*:/, false)
+        ? 'AliasedField'
+        : 'Field';
   },
   // Note: this minor deviation of "AliasedField" simplifies the lookahead.
   AliasedField: [

--- a/packages/parser/src/onlineParser.js
+++ b/packages/parser/src/onlineParser.js
@@ -149,7 +149,9 @@ function getToken(
     // the current token, otherwise expect based on the current step.
     let expected: any =
       typeof state.rule === 'function'
-        ? state.step === 0 ? state.rule(token, stream) : null
+        ? state.step === 0
+          ? state.rule(token, stream)
+          : null
         : state.rule[state.step];
 
     // Seperator between list elements if necessary.

--- a/packages/server/src/GraphQLCache.js
+++ b/packages/server/src/GraphQLCache.js
@@ -544,9 +544,9 @@ export class GraphQLCache implements GraphQLCacheInterface {
   }
 
   /**
-  * Given a list of GraphQL file metadata, read all files collected from watchman
-  * and create fragmentDefinitions and GraphQL files cache.
-  */
+   * Given a list of GraphQL file metadata, read all files collected from watchman
+   * and create fragmentDefinitions and GraphQL files cache.
+   */
   readAllGraphQLFiles = async (
     list: Array<GraphQLFileMetadata>,
   ): Promise<{
@@ -561,13 +561,13 @@ export class GraphQLCache implements GraphQLCacheInterface {
         this.promiseToReadGraphQLFile(fileInfo.filePath)
           .catch(error => {
             /**
-            * fs emits `EMFILE | ENFILE` error when there are too many
-            * open files - this can cause some fragment files not to be
-            * processed.  Solve this case by implementing a queue to save
-            * files failed to be processed because of `EMFILE` error,
-            * and await on Promises created with the next batch from the
-            * queue.
-            */
+             * fs emits `EMFILE | ENFILE` error when there are too many
+             * open files - this can cause some fragment files not to be
+             * processed.  Solve this case by implementing a queue to save
+             * files failed to be processed because of `EMFILE` error,
+             * and await on Promises created with the next batch from the
+             * queue.
+             */
             if (error.code === 'EMFILE' || error.code === 'ENFILE') {
               queue.push(fileInfo);
             }
@@ -587,9 +587,9 @@ export class GraphQLCache implements GraphQLCacheInterface {
   };
 
   /**
-  * Takes an array of GraphQL File information and batch-processes into a
-  * map of fragmentDefinitions and GraphQL file cache.
-  */
+   * Takes an array of GraphQL File information and batch-processes into a
+   * map of fragmentDefinitions and GraphQL file cache.
+   */
   processGraphQLFiles = (
     responses: Array<GraphQLFileInfo>,
   ): {
@@ -630,9 +630,9 @@ export class GraphQLCache implements GraphQLCacheInterface {
   };
 
   /**
-  * Returns a Promise to read a GraphQL file and return a GraphQL metadata
-  * including a parsed AST.
-  */
+   * Returns a Promise to read a GraphQL file and return a GraphQL metadata
+   * including a parsed AST.
+   */
   promiseToReadGraphQLFile = (
     filePath: Uri,
   ): Promise<{

--- a/packages/server/src/Logger.js
+++ b/packages/server/src/Logger.js
@@ -38,8 +38,9 @@ export class Logger implements VSCodeLogger {
 
     this._logFilePath = join(
       dir,
-      `graphql-language-service-log-${os.userInfo()
-        .username}-${getDateString()}.log`,
+      `graphql-language-service-log-${
+        os.userInfo().username
+      }-${getDateString()}.log`,
     );
 
     this._stream = null;

--- a/packages/types/src/index.js
+++ b/packages/types/src/index.js
@@ -30,26 +30,26 @@ import type {GraphQLConfig, GraphQLProjectConfig} from 'graphql-config';
 export type TokenPattern = string | ((char: string) => boolean) | RegExp;
 
 export interface CharacterStream {
-  getStartOfToken: () => number,
-  getCurrentPosition: () => number,
-  eol: () => boolean,
-  sol: () => boolean,
-  peek: () => string | null,
-  next: () => string,
-  eat: (pattern: TokenPattern) => string | void,
-  eatWhile: (match: TokenPattern) => boolean,
-  eatSpace: () => boolean,
-  skipToEnd: () => void,
-  skipTo: (position: number) => void,
+  getStartOfToken: () => number;
+  getCurrentPosition: () => number;
+  eol: () => boolean;
+  sol: () => boolean;
+  peek: () => string | null;
+  next: () => string;
+  eat: (pattern: TokenPattern) => string | void;
+  eatWhile: (match: TokenPattern) => boolean;
+  eatSpace: () => boolean;
+  skipToEnd: () => void;
+  skipTo: (position: number) => void;
   match: (
     pattern: TokenPattern,
     consume: ?boolean,
     caseFold: ?boolean,
-  ) => Array<string> | boolean,
-  backUp: (num: number) => void,
-  column: () => number,
-  indentation: () => number,
-  current: () => string,
+  ) => Array<string> | boolean;
+  backUp: (num: number) => void;
+  column: () => number;
+  indentation: () => number;
+  current: () => string;
 }
 
 // Cache and config-related.
@@ -80,56 +80,56 @@ export type GraphQLConfigurationExtension = {
 };
 
 export interface GraphQLCache {
-  getGraphQLConfig: () => GraphQLConfig,
+  getGraphQLConfig: () => GraphQLConfig;
 
   getFragmentDependencies: (
     query: string,
     fragmentDefinitions: ?Map<string, FragmentInfo>,
-  ) => Promise<Array<FragmentInfo>>,
+  ) => Promise<Array<FragmentInfo>>;
 
   getFragmentDependenciesForAST: (
     parsedQuery: ASTNode,
     fragmentDefinitions: Map<string, FragmentInfo>,
-  ) => Promise<Array<FragmentInfo>>,
+  ) => Promise<Array<FragmentInfo>>;
 
   getFragmentDefinitions: (
     graphQLConfig: GraphQLProjectConfig,
-  ) => Promise<Map<string, FragmentInfo>>,
+  ) => Promise<Map<string, FragmentInfo>>;
 
   +updateFragmentDefinition: (
     rootDir: Uri,
     filePath: Uri,
     contents: Array<CachedContent>,
-  ) => Promise<void>,
+  ) => Promise<void>;
 
   +updateFragmentDefinitionCache: (
     rootDir: Uri,
     filePath: Uri,
     exists: boolean,
-  ) => Promise<void>,
+  ) => Promise<void>;
 
   getSchema: (
     appName: ?string,
     queryHasExtensions?: ?boolean,
-  ) => Promise<?GraphQLSchema>,
+  ) => Promise<?GraphQLSchema>;
 
   handleWatchmanSubscribeEvent: (
     rootDir: string,
     projectConfig: GraphQLProjectConfig,
-  ) => (result: Object) => void,
+  ) => (result: Object) => void;
 }
 
 // online-parser related
 export interface Position {
-  line: number,
-  character: number,
-  lessThanOrEqualTo: (position: Position) => boolean,
+  line: number;
+  character: number;
+  lessThanOrEqualTo: (position: Position) => boolean;
 }
 
 export interface Range {
-  start: Position,
-  end: Position,
-  containsPosition: (position: Position) => boolean,
+  start: Position;
+  end: Position;
+  containsPosition: (position: Position) => boolean;
 }
 
 export type CachedContent = {
@@ -280,11 +280,11 @@ export type Outline = {
 };
 
 export interface DidChangeWatchedFilesParams {
-  changes: FileEvent[],
+  changes: FileEvent[];
 }
 export interface FileEvent {
-  uri: string,
-  type: FileChangeType,
+  uri: string;
+  type: FileChangeType;
 }
 export const FileChangeTypeKind = {
   Created: 1,

--- a/resources/pretty.js
+++ b/resources/pretty.js
@@ -33,7 +33,7 @@ const {stdout, stderr, status, error} = spawnSync(executable, [
   glob,
 ]);
 const out = stdout.toString().trim();
-const err = stdout.toString().trim();
+const err = stderr.toString().trim();
 
 function print(message) {
   if (message) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2673,9 +2673,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.5.3:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.0.tgz#47481588f41f7c90f63938feb202ac82554e7150"
+prettier@1.13:
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.3.tgz#e74c09a7df6519d472ca6febaa37cf7addb48a20"
 
 private@^0.1.6, private@^0.1.7:
   version "0.1.7"


### PR DESCRIPTION
The existing build fails for node v10. Bumping prettier fixes this issue. 

Side-effect is that multiple changes are introduced after running `npm run prettier` with the new prettier version. 

This PR also fixes a typo in `pretty.js` that correctly logs `stderr`. It is related and I think it belongs to the same PR :)