### PR TITLE
Feature go to definition SDL - input, enum, type

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Currently supported features include:
 - Diagnostics (GraphQL syntax linting/validations) (**spec-compliant**)
 - Autocomplete suggestions (**spec-compliant**)
 - Hyperlink to fragment definitions (**spec-compliant**)
+- Hyperlink to named types (type, input, enum) definitions (**spec-compliant**)
 - Outline view support for queries
 
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Partial support for [Microsoft's Language Server Protocol](https://github.com/Mi
 Currently supported features include:
 - Diagnostics (GraphQL syntax linting/validations) (**spec-compliant**)
 - Autocomplete suggestions (**spec-compliant**)
-- Hyperlink to fragment definitions (**spec-compliant**)
-- Hyperlink to named types (type, input, enum) definitions (**spec-compliant**)
+- Hyperlink to fragment definitions and named types (type, input, enum) definitions (**spec-compliant**)
 - Outline view support for queries
 
 

--- a/packages/interface/src/GraphQLLanguageService.js
+++ b/packages/interface/src/GraphQLLanguageService.js
@@ -14,7 +14,6 @@ import type {
   FragmentDefinitionNode,
   OperationDefinitionNode,
   TypeDefinitionNode,
-  TypeExtensionNode,
   NamedTypeNode,
 } from 'graphql';
 import type {
@@ -258,20 +257,19 @@ export class GraphQLLanguageService {
       objectTypeDefinitions,
     );
 
-    const localObjectTypeDefinitions = ast.definitions.filter(definition =>
-      [
-        OBJECT_TYPE_DEFINITION,
-        INPUT_OBJECT_TYPE_DEFINITION,
-        ENUM_TYPE_DEFINITION,
-      ].includes(definition.kind),
+    const localObjectTypeDefinitions = ast.definitions.filter(
+      definition =>
+        definition.kind === OBJECT_TYPE_DEFINITION ||
+        definition.kind === INPUT_OBJECT_TYPE_DEFINITION ||
+        definition.kind === ENUM_TYPE_DEFINITION,
     );
 
     const typeCastedDefs = ((localObjectTypeDefinitions: any): Array<
-      TypeDefinitionNode | TypeExtensionNode,
+      TypeDefinitionNode,
     >);
 
     const localOperationDefinationInfos = typeCastedDefs.map(
-      (definition: TypeDefinitionNode | TypeExtensionNode) => ({
+      (definition: TypeDefinitionNode) => ({
         filePath,
         content: query,
         definition,

--- a/packages/interface/src/GraphQLLanguageService.js
+++ b/packages/interface/src/GraphQLLanguageService.js
@@ -13,7 +13,10 @@ import type {
   FragmentSpreadNode,
   FragmentDefinitionNode,
   OperationDefinitionNode,
-  NamedType,
+  ObjectTypeDefinitionNode,
+  InputObjectTypeDefinitionNode,
+  EnumTypeDefinitionNode,
+  NamedTypeNode,
 } from 'graphql';
 import type {
   CompletionItem,
@@ -243,7 +246,7 @@ export class GraphQLLanguageService {
   async _getDefinitionForNamedType(
     query: string,
     ast: DocumentNode,
-    node: NamedType,
+    node: NamedTypeNode,
     filePath: Uri,
     projectConfig: GraphQLProjectConfig,
   ): Promise<?DefinitionQueryResult> {
@@ -265,15 +268,17 @@ export class GraphQLLanguageService {
     );
 
     const typeCastedDefs = ((localObjectTypeDefinitions: any): Array<
-      ObjectTypeDefinition | InputObjectTypeDefinition | EnumTypeDefinition,
+      | ObjectTypeDefinitionNode
+      | InputObjectTypeDefinitionNode
+      | EnumTypeDefinitionNode,
     >);
 
     const localOperationDefinationInfos = typeCastedDefs.map(
       (
         definition:
-          | ObjectTypeDefinition
-          | InputObjectTypeDefinition
-          | EnumTypeDefinition,
+          | ObjectTypeDefinitionNode
+          | InputObjectTypeDefinitionNode
+          | EnumTypeDefinitionNode,
       ) => ({
         filePath,
         content: query,

--- a/packages/interface/src/GraphQLLanguageService.js
+++ b/packages/interface/src/GraphQLLanguageService.js
@@ -13,9 +13,8 @@ import type {
   FragmentSpreadNode,
   FragmentDefinitionNode,
   OperationDefinitionNode,
-  ObjectTypeDefinitionNode,
-  InputObjectTypeDefinitionNode,
-  EnumTypeDefinitionNode,
+  TypeDefinitionNode,
+  TypeExtensionNode,
   NamedTypeNode,
 } from 'graphql';
 import type {
@@ -268,18 +267,11 @@ export class GraphQLLanguageService {
     );
 
     const typeCastedDefs = ((localObjectTypeDefinitions: any): Array<
-      | ObjectTypeDefinitionNode
-      | InputObjectTypeDefinitionNode
-      | EnumTypeDefinitionNode,
+      TypeDefinitionNode | TypeExtensionNode,
     >);
 
     const localOperationDefinationInfos = typeCastedDefs.map(
-      (
-        definition:
-          | ObjectTypeDefinitionNode
-          | InputObjectTypeDefinitionNode
-          | EnumTypeDefinitionNode,
-      ) => ({
+      (definition: TypeDefinitionNode | TypeExtensionNode) => ({
         filePath,
         content: query,
         definition,

--- a/packages/interface/src/__tests__/GraphQLLanguageService-test.js
+++ b/packages/interface/src/__tests__/GraphQLLanguageService-test.js
@@ -16,13 +16,50 @@ import {GraphQLConfig} from 'graphql-config';
 import {GraphQLLanguageService} from '../GraphQLLanguageService';
 
 const MOCK_CONFIG = {
-  includes: ['./queries/**'],
+  schemaPath: './__schema__/StarWarsSchema.graphql',
+  includes: ['./queries/**', '**/*.graphql'],
 };
 
 describe('GraphQLLanguageService', () => {
   const mockCache: any = {
     getGraphQLConfig() {
       return new GraphQLConfig(MOCK_CONFIG, join(__dirname, '.graphqlconfig'));
+    },
+
+    getObjectTypeDefinitions() {
+      return {
+        Episode: {
+          filePath: 'fake file path',
+          content: 'fake file content',
+          definition: {
+            name: {
+              value: 'Episode',
+            },
+            loc: {
+              start: 293,
+              end: 335,
+            },
+          },
+        },
+      };
+    },
+
+    getObjectTypeDependenciesForAST() {
+      return [
+        {
+          filePath: 'fake file path',
+          content: 'fake file content',
+          definition: {
+            name: {
+              value: 'Episode',
+            },
+            loc: {
+              start: 293,
+              end: 335,
+            },
+          },
+        },
+      ];
     },
   };
 
@@ -37,5 +74,14 @@ describe('GraphQLLanguageService', () => {
       './queries/testQuery.graphql',
     );
     expect(diagnostics.length).to.equal(1);
+  });
+
+  it('runs definition service as expected', async () => {
+    const definitionQueryResult = await languageService.getDefinition(
+      'type Query { hero(episode: Episode): Character }',
+      {line: 0, character: 28},
+      './queries/definitionQuery.graphql',
+    );
+    expect(definitionQueryResult.definitions.length).to.equal(1);
   });
 });

--- a/packages/interface/src/__tests__/getDefinition-test.js
+++ b/packages/interface/src/__tests__/getDefinition-test.js
@@ -11,9 +11,46 @@
 import {expect} from 'chai';
 import {describe, it} from 'mocha';
 import {parse} from 'graphql';
-import {getDefinitionQueryResultForFragmentSpread} from '../getDefinition';
+import {
+  getDefinitionQueryResultForFragmentSpread,
+  getDefinitionQueryResultForNamedType,
+} from '../getDefinition';
 
 describe('getDefinition', () => {
+  describe('getDefinitionQueryResultForNamedType', () => {
+    it('returns correct Position', async () => {
+      const query = `type Query {
+        hero(episode: Episode): Character
+      }
+      
+      type Episode {
+        id: ID!
+      }
+      `;
+      const parsedQuery = parse(query);
+      const namedTypeDefinition = parsedQuery.definitions[0].fields[0].type;
+
+      const result = await getDefinitionQueryResultForNamedType(
+        query,
+        {
+          ...namedTypeDefinition,
+        },
+        [
+          {
+            file: 'someFile',
+            content: query,
+            definition: {
+              ...namedTypeDefinition,
+            },
+          },
+        ],
+      );
+      expect(result.definitions.length).to.equal(1);
+      expect(result.definitions[0].position.line).to.equal(1);
+      expect(result.definitions[0].position.character).to.equal(32);
+    });
+  });
+
   describe('getDefinitionQueryResultForFragmentSpread', () => {
     it('returns correct Position', async () => {
       const query = `query A {
@@ -39,7 +76,7 @@ describe('getDefinition', () => {
       );
       expect(result.definitions.length).to.equal(1);
       expect(result.definitions[0].position.line).to.equal(1);
-      expect(result.definitions[0].position.character).to.equal(15);
+      expect(result.definitions[0].position.character).to.equal(6);
     });
   });
 });

--- a/packages/interface/src/__tests__/queries/definitionQuery.graphql
+++ b/packages/interface/src/__tests__/queries/definitionQuery.graphql
@@ -1,0 +1,1 @@
+type Query { hero(episode: Episode): Character }

--- a/packages/interface/src/getDefinition.js
+++ b/packages/interface/src/getDefinition.js
@@ -15,7 +15,6 @@ import type {
   OperationDefinitionNode,
   NamedTypeNode,
   TypeDefinitionNode,
-  TypeExtensionNode,
 } from 'graphql';
 import type {
   Definition,
@@ -123,7 +122,7 @@ function getDefinitionForFragmentDefinition(
 function getDefinitionForNodeDefinition(
   path: Uri,
   text: string,
-  definition: TypeDefinitionNode | TypeExtensionNode,
+  definition: TypeDefinitionNode,
 ): Definition {
   const name = definition.name;
   invariant(name, 'Expected ASTNode to have a Name.');

--- a/packages/interface/src/getDefinition.js
+++ b/packages/interface/src/getDefinition.js
@@ -55,10 +55,9 @@ export async function getDefinitionQueryResultForNamedType(
     process.stderr.write(`Definition not found for GraphQL type ${name}`);
     return {queryRange: [], definitions: []};
   }
-  const definitions: Array<
-    Definition,
-  > = defNodes.map(({filePath, content, definition}) =>
-    getDefinitionForNodeDefinition(filePath || '', content, definition),
+  const definitions: Array<Definition> = defNodes.map(
+    ({filePath, content, definition}) =>
+      getDefinitionForNodeDefinition(filePath || '', content, definition),
   );
   return {
     definitions,

--- a/packages/interface/src/getDefinition.js
+++ b/packages/interface/src/getDefinition.js
@@ -39,6 +39,30 @@ function getPosition(text: string, node: ASTNode): Position {
   return offsetToPosition(text, location.start);
 }
 
+export async function getDefinitionQueryResultForNamedType(
+  text: string,
+  node: NamedType,
+  dependencies: Array<NamedTypeInfo>,
+): Promise<DefinitionQueryResult> {
+  const name = node.name.value;
+  const defNodes = dependencies.filter(
+    ({definition}) => definition.name.value === name,
+  );
+  if (defNodes.length === 0) {
+    process.stderr.write(`Definition not found for GraphQL type ${name}`);
+    return {queryRange: [], definitions: []};
+  }
+  const definitions: Array<
+    Definition,
+  > = defNodes.map(({filePath, content, definition}) =>
+    getDefinitionForNodeDefinition(filePath || '', content, definition),
+  );
+  return {
+    definitions,
+    queryRange: definitions.map(_ => getRange(text, node)),
+  };
+}
+
 export async function getDefinitionQueryResultForFragmentSpread(
   text: string,
   fragment: FragmentSpreadNode,
@@ -83,7 +107,25 @@ function getDefinitionForFragmentDefinition(
   invariant(name, 'Expected ASTNode to have a Name.');
   return {
     path,
-    position: getPosition(text, name),
+    position: getPosition(text, definition),
+    range: getRange(text, definition),
+    name: name.value || '',
+    language: LANGUAGE,
+    // This is a file inside the project root, good enough for now
+    projectRoot: path,
+  };
+}
+
+function getDefinitionForNodeDefinition(
+  path: Uri,
+  text: string,
+  definition: NamedType,
+): Definition {
+  const name = definition.name;
+  invariant(name, 'Expected ASTNode to have a Name.');
+  return {
+    path,
+    position: getPosition(text, definition),
     range: getRange(text, definition),
     name: name.value || '',
     language: LANGUAGE,

--- a/packages/interface/src/getDefinition.js
+++ b/packages/interface/src/getDefinition.js
@@ -14,6 +14,8 @@ import type {
   FragmentDefinitionNode,
   OperationDefinitionNode,
   NamedTypeNode,
+  TypeDefinitionNode,
+  TypeExtensionNode,
 } from 'graphql';
 import type {
   Definition,
@@ -22,7 +24,7 @@ import type {
   Position,
   Range,
   Uri,
-  NamedTypeInfo,
+  ObjectTypeInfo,
 } from 'graphql-language-service-types';
 import {locToRange, offsetToPosition} from 'graphql-language-service-utils';
 import invariant from 'assert';
@@ -44,11 +46,11 @@ function getPosition(text: string, node: ASTNode): Position {
 export async function getDefinitionQueryResultForNamedType(
   text: string,
   node: NamedTypeNode,
-  dependencies: Array<NamedTypeInfo>,
+  dependencies: Array<ObjectTypeInfo>,
 ): Promise<DefinitionQueryResult> {
   const name = node.name.value;
   const defNodes = dependencies.filter(
-    ({definition}) => definition.name.value === name,
+    ({definition}) => definition.name && definition.name.value === name,
   );
   if (defNodes.length === 0) {
     process.stderr.write(`Definition not found for GraphQL type ${name}`);
@@ -121,7 +123,7 @@ function getDefinitionForFragmentDefinition(
 function getDefinitionForNodeDefinition(
   path: Uri,
   text: string,
-  definition: NamedTypeNode,
+  definition: TypeDefinitionNode | TypeExtensionNode,
 ): Definition {
   const name = definition.name;
   invariant(name, 'Expected ASTNode to have a Name.');

--- a/packages/interface/src/getDefinition.js
+++ b/packages/interface/src/getDefinition.js
@@ -13,6 +13,7 @@ import type {
   FragmentSpreadNode,
   FragmentDefinitionNode,
   OperationDefinitionNode,
+  NamedTypeNode,
 } from 'graphql';
 import type {
   Definition,
@@ -21,6 +22,7 @@ import type {
   Position,
   Range,
   Uri,
+  NamedTypeInfo,
 } from 'graphql-language-service-types';
 import {locToRange, offsetToPosition} from 'graphql-language-service-utils';
 import invariant from 'assert';
@@ -41,7 +43,7 @@ function getPosition(text: string, node: ASTNode): Position {
 
 export async function getDefinitionQueryResultForNamedType(
   text: string,
-  node: NamedType,
+  node: NamedTypeNode,
   dependencies: Array<NamedTypeInfo>,
 ): Promise<DefinitionQueryResult> {
   const name = node.name.value;
@@ -119,7 +121,7 @@ function getDefinitionForFragmentDefinition(
 function getDefinitionForNodeDefinition(
   path: Uri,
   text: string,
-  definition: NamedType,
+  definition: NamedTypeNode,
 ): Definition {
   const name = definition.name;
   invariant(name, 'Expected ASTNode to have a Name.');

--- a/packages/server/src/GraphQLCache.js
+++ b/packages/server/src/GraphQLCache.js
@@ -16,6 +16,7 @@ import type {
   GraphQLFileMetadata,
   GraphQLFileInfo,
   FragmentInfo,
+  ObjectTypeInfo,
   Uri,
   GraphQLProjectConfig,
 } from 'graphql-language-service-types';
@@ -65,6 +66,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
   _schemaMap: Map<Uri, GraphQLSchema>;
   _typeExtensionMap: Map<Uri, number>;
   _fragmentDefinitionsCache: Map<Uri, Map<string, FragmentInfo>>;
+  _typeDefinitionsCache: Map<Uri, Map<string, ObjectTypeInfo>>;
 
   constructor(configDir: Uri, graphQLConfig: GraphQLConfig): void {
     this._configDir = configDir;
@@ -72,6 +74,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
     this._graphQLFileListCache = new Map();
     this._schemaMap = new Map();
     this._fragmentDefinitionsCache = new Map();
+    this._typeDefinitionsCache = new Map();
     this._typeExtensionMap = new Map();
   }
 
@@ -175,6 +178,112 @@ export class GraphQLCache implements GraphQLCacheInterface {
     this._graphQLFileListCache.set(rootDir, graphQLFileMap);
 
     return fragmentDefinitions;
+  };
+
+  getObjectTypeDependencies = async (
+    query: string,
+    objectTypeDefinitions: ?Map<string, ObjectTypeInfo>,
+  ): Promise<Array<ObjectTypeInfo>> => {
+    // If there isn't context for object type references,
+    // return an empty array.
+    if (!objectTypeDefinitions) {
+      return [];
+    }
+    // If the query cannot be parsed, validations cannot happen yet.
+    // Return an empty array.
+    let parsedQuery;
+    try {
+      parsedQuery = parse(query);
+    } catch (error) {
+      return [];
+    }
+    return this.getObjectTypeDependenciesForAST(
+      parsedQuery,
+      objectTypeDefinitions,
+    );
+  };
+
+  getObjectTypeDependenciesForAST = async (
+    parsedQuery: ASTNode,
+    objectTypeDefinitions: Map<string, ObjectTypeInfo>,
+  ): Promise<Array<ObjectTypeInfo>> => {
+    if (!objectTypeDefinitions) {
+      return [];
+    }
+
+    const existingObjectTypes = new Map();
+    const referencedObjectTypes = new Set();
+
+    visit(parsedQuery, {
+      ObjectTypeDefinition(node) {
+        existingObjectTypes.set(node.name.value, true);
+      },
+      InputObjectTypeDefinition(node) {
+        existingObjectTypes.set(node.name.value, true);
+      },
+      EnumTypeDefinition(node) {
+        existingObjectTypes.set(node.name.value, true);
+      },
+      NamedType(node) {
+        if (!referencedObjectTypes.has(node.name.value)) {
+          referencedObjectTypes.add(node.name.value);
+        }
+      },
+    });
+
+    const asts = new Set();
+    referencedObjectTypes.forEach(name => {
+      if (!existingObjectTypes.has(name) && objectTypeDefinitions.has(name)) {
+        asts.add(nullthrows(objectTypeDefinitions.get(name)));
+      }
+    });
+
+    const referencedObjects = [];
+
+    asts.forEach(ast => {
+      visit(ast.definition, {
+        NamedType(node) {
+          if (
+            !referencedObjectTypes.has(node.name.value) &&
+            objectTypeDefinitions.get(node.name.value)
+          ) {
+            asts.add(nullthrows(objectTypeDefinitions.get(node.name.value)));
+            referencedObjectTypes.add(node.name.value);
+          }
+        },
+      });
+      if (!existingObjectTypes.has(ast.definition.name.value)) {
+        referencedObjects.push(ast);
+      }
+    });
+
+    return referencedObjects;
+  };
+
+  getObjectTypeDefinitions = async (
+    projectConfig: GraphQLProjectConfig,
+  ): Promise<Map<string, ObjectTypeInfo>> => {
+    // This function may be called from other classes.
+    // If then, check the cache first.
+    const rootDir = projectConfig.configDir;
+    if (this._typeDefinitionsCache.has(rootDir)) {
+      return this._typeDefinitionsCache.get(rootDir) || new Map();
+    }
+    const filesFromInputDirs = await this._readFilesFromInputDirs(
+      rootDir,
+      projectConfig.includes,
+    );
+    const list = filesFromInputDirs.filter(fileInfo =>
+      projectConfig.includesFile(fileInfo.filePath),
+    );
+    const {
+      objectTypeDefinitions,
+      graphQLFileMap,
+    } = await this.readAllGraphQLFiles(list);
+    this._typeDefinitionsCache.set(rootDir, objectTypeDefinitions);
+    this._graphQLFileListCache.set(rootDir, graphQLFileMap);
+
+    return objectTypeDefinitions;
   };
 
   handleWatchmanSubscribeEvent = (
@@ -550,6 +659,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
   readAllGraphQLFiles = async (
     list: Array<GraphQLFileMetadata>,
   ): Promise<{
+    objectTypeDefinitions: Map<string, ObjectTypeInfo>,
     fragmentDefinitions: Map<string, FragmentInfo>,
     graphQLFileMap: Map<string, GraphQLFileInfo>,
   }> => {
@@ -593,9 +703,11 @@ export class GraphQLCache implements GraphQLCacheInterface {
   processGraphQLFiles = (
     responses: Array<GraphQLFileInfo>,
   ): {
+    objectTypeDefinitions: Map<string, ObjectTypeInfo>,
     fragmentDefinitions: Map<string, FragmentInfo>,
     graphQLFileMap: Map<string, GraphQLFileInfo>,
   } => {
+    const objectTypeDefinitions = new Map();
     const fragmentDefinitions = new Map();
     const graphQLFileMap = new Map();
 
@@ -607,6 +719,19 @@ export class GraphQLCache implements GraphQLCacheInterface {
           ast.definitions.forEach(definition => {
             if (definition.kind === FRAGMENT_DEFINITION) {
               fragmentDefinitions.set(definition.name.value, {
+                filePath,
+                content,
+                definition,
+              });
+            }
+            if (
+              [
+                OBJECT_TYPE_DEFINITION,
+                INPUT_OBJECT_TYPE_DEFINITION,
+                ENUM_TYPE_DEFINITION,
+              ].includes(definition.kind)
+            ) {
+              objectTypeDefinitions.set(definition.name.value, {
                 filePath,
                 content,
                 definition,
@@ -626,7 +751,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
       });
     });
 
-    return {fragmentDefinitions, graphQLFileMap};
+    return {objectTypeDefinitions, fragmentDefinitions, graphQLFileMap};
   };
 
   /**

--- a/packages/server/src/GraphQLCache.js
+++ b/packages/server/src/GraphQLCache.js
@@ -725,11 +725,9 @@ export class GraphQLCache implements GraphQLCacheInterface {
               });
             }
             if (
-              [
-                OBJECT_TYPE_DEFINITION,
-                INPUT_OBJECT_TYPE_DEFINITION,
-                ENUM_TYPE_DEFINITION,
-              ].includes(definition.kind)
+              definition.kind === OBJECT_TYPE_DEFINITION ||
+              definition.kind === INPUT_OBJECT_TYPE_DEFINITION ||
+              definition.kind === ENUM_TYPE_DEFINITION
             ) {
               objectTypeDefinitions.set(definition.name.value, {
                 filePath,

--- a/packages/server/src/MessageProcessor.js
+++ b/packages/server/src/MessageProcessor.js
@@ -279,6 +279,7 @@ export class MessageProcessor {
     }
 
     this._updateFragmentDefinition(uri, contents);
+    this._updateObjectTypeDefinition(uri, contents);
 
     // Send the diagnostics onChange as well
     const diagnostics = [];
@@ -482,6 +483,7 @@ export class MessageProcessor {
           const contents = getQueryAndRange(text, uri);
 
           this._updateFragmentDefinition(uri, contents);
+          this._updateObjectTypeDefinition(uri, contents);
 
           const diagnostics = (await Promise.all(
             contents.map(async ({query, range}) => {
@@ -511,6 +513,11 @@ export class MessageProcessor {
           return {uri, diagnostics};
         } else if (change.type === FileChangeTypeKind.Deleted) {
           this._graphQLCache.updateFragmentDefinitionCache(
+            this._graphQLCache.getGraphQLConfig().configDir,
+            change.uri,
+            false,
+          );
+          this._graphQLCache.updateObjectTypeDefinitionCache(
             this._graphQLCache.getGraphQLConfig().configDir,
             change.uri,
             false,
@@ -606,6 +613,19 @@ export class MessageProcessor {
     const rootDir = this._graphQLCache.getGraphQLConfig().configDir;
 
     await this._graphQLCache.updateFragmentDefinition(
+      rootDir,
+      new URL(uri).pathname,
+      contents,
+    );
+  }
+
+  async _updateObjectTypeDefinition(
+    uri: Uri,
+    contents: Array<CachedContent>,
+  ): Promise<void> {
+    const rootDir = this._graphQLCache.getGraphQLConfig().configDir;
+
+    await this._graphQLCache.updateObjectTypeDefinition(
       rootDir,
       new URL(uri).pathname,
       contents,

--- a/packages/server/src/__tests__/GraphQLCache-test.js
+++ b/packages/server/src/__tests__/GraphQLCache-test.js
@@ -183,4 +183,41 @@ describe('GraphQLCache', () => {
       expect(fragmentDefinitions.get('testFragment')).to.be.undefined;
     });
   });
+
+  describe('getNamedTypeDependencies', () => {
+    const query = `type Query {
+        hero(episode: Episode): Character
+      }
+      
+      type Episode {
+        id: ID!
+      }
+      `;
+    const parsedQuery = parse(query);
+
+    const namedTypeDefinitions = new Map();
+    namedTypeDefinitions.set('Character', {
+      file: 'someOtherFilePath',
+      content: query,
+      definition: {
+        kind: 'ObjectTypeDefinition',
+        name: {
+          kind: 'Name',
+          value: 'Character',
+        },
+        loc: {
+          start: 0,
+          end: 0,
+        },
+      },
+    });
+
+    it('finds named types referenced from the SDL', async () => {
+      const result = await cache.getObjectTypeDependenciesForAST(
+        parsedQuery,
+        namedTypeDefinitions,
+      );
+      expect(result.length).to.equal(1);
+    });
+  });
 });

--- a/packages/server/src/__tests__/MessageProcessor-test.js
+++ b/packages/server/src/__tests__/MessageProcessor-test.js
@@ -48,6 +48,7 @@ describe('MessageProcessor', () => {
         };
       },
       updateFragmentDefinition() {},
+      updateObjectTypeDefinition() {},
       handleWatchmanSubscribeEvent() {},
     };
     messageProcessor._languageService = {

--- a/packages/types/src/index.js
+++ b/packages/types/src/index.js
@@ -98,6 +98,18 @@ export interface GraphQLCache {
     graphQLConfig: GraphQLProjectConfig,
   ) => Promise<Map<string, ObjectTypeInfo>>,
 
+  +updateObjectTypeDefinition: (
+    rootDir: Uri,
+    filePath: Uri,
+    contents: Array<CachedContent>,
+  ) => Promise<void>;
+
+  +updateObjectTypeDefinitionCache: (
+    rootDir: Uri,
+    filePath: Uri,
+    exists: boolean,
+  ) => Promise<void>;
+
   getFragmentDependencies: (
     query: string,
     fragmentDefinitions: ?Map<string, FragmentInfo>,

--- a/packages/types/src/index.js
+++ b/packages/types/src/index.js
@@ -13,7 +13,10 @@ import type {
   ASTNode,
   DocumentNode,
   FragmentDefinitionNode,
-  NamedType,
+  NamedTypeNode,
+  ObjectTypeDefinitionNode,
+  InputObjectTypeDefinitionNode,
+  EnumTypeDefinitionNode,
 } from 'graphql/language';
 import type {ValidationContext} from 'graphql/validation';
 import type {
@@ -230,16 +233,16 @@ export type FragmentInfo = {
 export type NamedTypeInfo = {
   filePath?: Uri,
   content: string,
-  definition: NamedType,
+  definition: NamedTypeNode,
 };
 
 export type ObjectTypeInfo = {
   filePath?: Uri,
   content: string,
   definition:
-    | ObjectTypeDefinition
-    | InputObjectTypeDefinition
-    | EnumTypeDefinition,
+    | ObjectTypeDefinitionNode
+    | InputObjectTypeDefinitionNode
+    | EnumTypeDefinitionNode,
 };
 
 export type CustomValidationRule = (context: ValidationContext) => Object;

--- a/packages/types/src/index.js
+++ b/packages/types/src/index.js
@@ -15,7 +15,6 @@ import type {
   FragmentDefinitionNode,
   NamedTypeNode,
   TypeDefinitionNode,
-  TypeExtensionNode,
 } from 'graphql/language';
 import type {ValidationContext} from 'graphql/validation';
 import type {
@@ -238,7 +237,7 @@ export type NamedTypeInfo = {
 export type ObjectTypeInfo = {
   filePath?: Uri,
   content: string,
-  definition: TypeDefinitionNode | TypeExtensionNode,
+  definition: TypeDefinitionNode,
 };
 
 export type CustomValidationRule = (context: ValidationContext) => Object;

--- a/packages/types/src/index.js
+++ b/packages/types/src/index.js
@@ -87,16 +87,16 @@ export interface GraphQLCache {
   getObjectTypeDependencies: (
     query: string,
     fragmentDefinitions: ?Map<string, ObjectTypeInfo>,
-  ) => Promise<Array<ObjectTypeInfo>>,
+  ) => Promise<Array<ObjectTypeInfo>>;
 
   getObjectTypeDependenciesForAST: (
     parsedQuery: ASTNode,
     fragmentDefinitions: Map<string, ObjectTypeInfo>,
-  ) => Promise<Array<ObjectTypeInfo>>,
+  ) => Promise<Array<ObjectTypeInfo>>;
 
   getObjectTypeDefinitions: (
     graphQLConfig: GraphQLProjectConfig,
-  ) => Promise<Map<string, ObjectTypeInfo>>,
+  ) => Promise<Map<string, ObjectTypeInfo>>;
 
   +updateObjectTypeDefinition: (
     rootDir: Uri,

--- a/packages/types/src/index.js
+++ b/packages/types/src/index.js
@@ -13,6 +13,7 @@ import type {
   ASTNode,
   DocumentNode,
   FragmentDefinitionNode,
+  NamedType,
 } from 'graphql/language';
 import type {ValidationContext} from 'graphql/validation';
 import type {
@@ -81,6 +82,20 @@ export type GraphQLConfigurationExtension = {
 
 export interface GraphQLCache {
   getGraphQLConfig: () => GraphQLConfig,
+
+  getObjectTypeDependencies: (
+    query: string,
+    fragmentDefinitions: ?Map<string, ObjectTypeInfo>,
+  ) => Promise<Array<ObjectTypeInfo>>,
+
+  getObjectTypeDependenciesForAST: (
+    parsedQuery: ASTNode,
+    fragmentDefinitions: Map<string, ObjectTypeInfo>,
+  ) => Promise<Array<ObjectTypeInfo>>,
+
+  getObjectTypeDefinitions: (
+    graphQLConfig: GraphQLProjectConfig,
+  ) => Promise<Map<string, ObjectTypeInfo>>,
 
   getFragmentDependencies: (
     query: string,
@@ -210,6 +225,21 @@ export type FragmentInfo = {
   filePath?: Uri,
   content: string,
   definition: FragmentDefinitionNode,
+};
+
+export type NamedTypeInfo = {
+  filePath?: Uri,
+  content: string,
+  definition: NamedType,
+};
+
+export type ObjectTypeInfo = {
+  filePath?: Uri,
+  content: string,
+  definition:
+    | ObjectTypeDefinition
+    | InputObjectTypeDefinition
+    | EnumTypeDefinition,
 };
 
 export type CustomValidationRule = (context: ValidationContext) => Object;

--- a/packages/types/src/index.js
+++ b/packages/types/src/index.js
@@ -14,9 +14,8 @@ import type {
   DocumentNode,
   FragmentDefinitionNode,
   NamedTypeNode,
-  ObjectTypeDefinitionNode,
-  InputObjectTypeDefinitionNode,
-  EnumTypeDefinitionNode,
+  TypeDefinitionNode,
+  TypeExtensionNode,
 } from 'graphql/language';
 import type {ValidationContext} from 'graphql/validation';
 import type {
@@ -239,10 +238,7 @@ export type NamedTypeInfo = {
 export type ObjectTypeInfo = {
   filePath?: Uri,
   content: string,
-  definition:
-    | ObjectTypeDefinitionNode
-    | InputObjectTypeDefinitionNode
-    | EnumTypeDefinitionNode,
+  definition: TypeDefinitionNode | TypeExtensionNode,
 };
 
 export type CustomValidationRule = (context: ValidationContext) => Object;


### PR DESCRIPTION
1. Implement go to definition for input, enum, type in SDL with some test cases

1. Support live file reload

1. Fixes a related test case in `getDefinition` that was found while implementing this part of code i.e. I think it belongs here

Thanks! :) 