### PR TITLE
WIP: Allow passing ParseOptions to parse() with GraphQL Language Server

### DIFF
--- a/packages/interface/src/GraphQLLanguageService.js
+++ b/packages/interface/src/GraphQLLanguageService.js
@@ -79,7 +79,7 @@ export class GraphQLLanguageService {
     const projectConfig = this._graphQLConfig.getConfigForFile(uri);
     const schemaPath = projectConfig.schemaPath;
     try {
-      const queryAST = parse(query);
+      const queryAST = parse(query, projectConfig.parseOptions);
       if (!schemaPath || uri !== schemaPath) {
         queryHasExtensions = queryAST.definitions.some(definition => {
           switch (definition.kind) {
@@ -121,6 +121,7 @@ export class GraphQLLanguageService {
     const fragmentDependencies = await this._graphQLCache.getFragmentDependencies(
       query,
       fragmentDefinitions,
+      projectConfig,
     );
     const dependenciesSource = fragmentDependencies.reduce(
       (prev, cur) => `${prev} ${print(cur.definition)}`,
@@ -131,7 +132,7 @@ export class GraphQLLanguageService {
 
     let validationAst = null;
     try {
-      validationAst = parse(source);
+      validationAst = parse(source, projectConfig.parseOptions);
     } catch (error) {
       // the query string is already checked to be parsed properly - errors
       // from this parse must be from corrupted fragment dependencies.
@@ -154,7 +155,7 @@ export class GraphQLLanguageService {
     }
 
     const schema = await this._graphQLCache
-      .getSchema(projectConfig.projectName, queryHasExtensions)
+      .getSchema(projectConfig, queryHasExtensions)
       .catch(() => null);
 
     if (!schema) {
@@ -171,7 +172,7 @@ export class GraphQLLanguageService {
   ): Promise<Array<CompletionItem>> {
     const projectConfig = this._graphQLConfig.getConfigForFile(filePath);
     const schema = await this._graphQLCache
-      .getSchema(projectConfig.projectName)
+      .getSchema(projectConfig)
       .catch(() => null);
 
     if (schema) {
@@ -187,7 +188,7 @@ export class GraphQLLanguageService {
   ): Promise<Hover.contents> {
     const projectConfig = this._graphQLConfig.getConfigForFile(filePath);
     const schema = await this._graphQLCache
-      .getSchema(projectConfig.projectName)
+      .getSchema(projectConfig)
       .catch(() => null);
 
     if (schema) {
@@ -205,7 +206,7 @@ export class GraphQLLanguageService {
 
     let ast;
     try {
-      ast = parse(query);
+      ast = parse(query, projectConfig.parseOptions);
     } catch (error) {
       return null;
     }

--- a/packages/types/src/index.js
+++ b/packages/types/src/index.js
@@ -87,6 +87,7 @@ export interface GraphQLCache {
   getObjectTypeDependencies: (
     query: string,
     fragmentDefinitions: ?Map<string, ObjectTypeInfo>,
+    projectConfig: GraphQLProjectConfig,
   ) => Promise<Array<ObjectTypeInfo>>;
 
   getObjectTypeDependenciesForAST: (
@@ -95,24 +96,27 @@ export interface GraphQLCache {
   ) => Promise<Array<ObjectTypeInfo>>;
 
   getObjectTypeDefinitions: (
-    graphQLConfig: GraphQLProjectConfig,
+    projectConfig: GraphQLProjectConfig,
   ) => Promise<Map<string, ObjectTypeInfo>>;
 
   +updateObjectTypeDefinition: (
     rootDir: Uri,
     filePath: Uri,
     contents: Array<CachedContent>,
+    projectConfig: GraphQLProjectConfig,
   ) => Promise<void>;
 
   +updateObjectTypeDefinitionCache: (
     rootDir: Uri,
     filePath: Uri,
     exists: boolean,
+    projectConfig: GraphQLProjectConfig,
   ) => Promise<void>;
 
   getFragmentDependencies: (
     query: string,
     fragmentDefinitions: ?Map<string, FragmentInfo>,
+    projectConfig: GraphQLProjectConfig,
   ) => Promise<Array<FragmentInfo>>;
 
   getFragmentDependenciesForAST: (
@@ -121,23 +125,25 @@ export interface GraphQLCache {
   ) => Promise<Array<FragmentInfo>>;
 
   getFragmentDefinitions: (
-    graphQLConfig: GraphQLProjectConfig,
+    projectConfig: GraphQLProjectConfig,
   ) => Promise<Map<string, FragmentInfo>>;
 
   +updateFragmentDefinition: (
     rootDir: Uri,
     filePath: Uri,
     contents: Array<CachedContent>,
+    projectConfig: GraphQLProjectConfig,
   ) => Promise<void>;
 
   +updateFragmentDefinitionCache: (
     rootDir: Uri,
     filePath: Uri,
     exists: boolean,
+    projectConfig: GraphQLProjectConfig,
   ) => Promise<void>;
 
   getSchema: (
-    appName: ?string,
+    projectConfig: GraphQLProjectConfig,
     queryHasExtensions?: ?boolean,
   ) => Promise<?GraphQLSchema>;
 


### PR DESCRIPTION
I want to pass some ParseOptions. The obvious way to do this is to specify it in `.graphqlconfig` and make graphql-language-service pick this up and respect it.

This is only a start. I haven't figured out the cleanest way to pass this to `GraphQLCache`. That will come next.