### PR TITLE
fix(Rules): adds whitespace exclusion for non breakable whitespace

### DIFF
--- a/packages/parser/src/Rules.js
+++ b/packages/parser/src/Rules.js
@@ -26,7 +26,8 @@ export const isIgnored = (ch: string) =>
   ch === ',' ||
   ch === '\n' ||
   ch === '\r' ||
-  ch === '\uFEFF';
+  ch === '\uFEFF' ||
+  ch === '\u00A0';
 
 /**
  * The lexer rules. These are exactly as described by the spec.


### PR DESCRIPTION
We use a GraphiQL and face an issue by copying queries from OneNote desktop to the GraphiQL web interface. 
We tracked the issue  down to this repository. 

The problem is that OneNote replaces all white spaces with non breaking spaces (\u00A0) . This results in codemirror as an invalid character. 

This should probably also be treated as a whitespace.
![image](https://user-images.githubusercontent.com/14233220/44154417-fd04cf1c-a0aa-11e8-883a-577753ae7384.png)
 