### PR TITLE
Upgrade to GraphQL 0.13.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-flowtype": "2.40.1",
     "eslint-plugin-prefer-object-spread": "1.2.1",
     "fetch-mock": "^6.0.0",
-    "flow-bin": "0.62.0",
+    "flow-bin": "0.68.0",
     "graphql": "^0.13.0",
     "graphql-language-service-interface": "^1.0.0-0",
     "graphql-language-service-parser": "^0.1.0-0",

--- a/packages/interface/src/GraphQLLanguageService.js
+++ b/packages/interface/src/GraphQLLanguageService.js
@@ -28,7 +28,18 @@ import type {
 import type {Position} from 'graphql-language-service-utils';
 import type {Hover} from 'vscode-languageserver-types';
 
+import {Kind, parse, print} from 'graphql';
+import {getAutocompleteSuggestions} from './getAutocompleteSuggestions';
+import {getHoverInformation} from './getHoverInformation';
+import {validateQuery, getRange, SEVERITY} from './getDiagnostics';
 import {
+  getDefinitionQueryResultForFragmentSpread,
+  getDefinitionQueryResultForDefinitionNode,
+  getDefinitionQueryResultForNamedType,
+} from './getDefinition';
+import {getASTNodeAtPosition} from 'graphql-language-service-utils';
+
+const {
   FRAGMENT_DEFINITION,
   OBJECT_TYPE_DEFINITION,
   INTERFACE_TYPE_DEFINITION,
@@ -46,18 +57,7 @@ import {
   FRAGMENT_SPREAD,
   OPERATION_DEFINITION,
   NAMED_TYPE,
-} from 'graphql/language/kinds';
-
-import {parse, print} from 'graphql';
-import {getAutocompleteSuggestions} from './getAutocompleteSuggestions';
-import {getHoverInformation} from './getHoverInformation';
-import {validateQuery, getRange, SEVERITY} from './getDiagnostics';
-import {
-  getDefinitionQueryResultForFragmentSpread,
-  getDefinitionQueryResultForDefinitionNode,
-  getDefinitionQueryResultForNamedType,
-} from './getDefinition';
-import {getASTNodeAtPosition} from 'graphql-language-service-utils';
+} = Kind;
 
 export class GraphQLLanguageService {
   _graphQLCache: GraphQLCache;

--- a/packages/interface/src/getOutline.js
+++ b/packages/interface/src/getOutline.js
@@ -14,9 +14,10 @@ import type {
   TokenKind,
 } from 'graphql-language-service-types';
 
-import {parse, visit} from 'graphql';
-import {INLINE_FRAGMENT} from 'graphql/language/kinds';
+import {Kind, parse, visit} from 'graphql';
 import {offsetToPosition} from 'graphql-language-service-utils';
+
+const {INLINE_FRAGMENT} = Kind;
 
 const OUTLINEABLE_KINDS = {
   Field: true,

--- a/packages/server/src/GraphQLCache.js
+++ b/packages/server/src/GraphQLCache.js
@@ -424,7 +424,6 @@ export class GraphQLCache implements GraphQLCacheInterface {
     const fileAndContent = exists
       ? await this.promiseToReadGraphQLFile(filePath)
       : null;
-    const graphQLFileInfo = {...fileAndContent, ...metrics};
 
     const existingFile = graphQLFileMap.get(filePath);
 
@@ -434,7 +433,8 @@ export class GraphQLCache implements GraphQLCacheInterface {
     // For delete, check `exists` and splice the file out.
     if (existingFile && !exists) {
       graphQLFileMap.delete(filePath);
-    } else if (graphQLFileInfo) {
+    } else if (fileAndContent) {
+      const graphQLFileInfo = {...fileAndContent, ...metrics};
       graphQLFileMap.set(filePath, graphQLFileInfo);
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1712,11 +1712,11 @@ graphql-request@^1.5.0:
   dependencies:
     cross-fetch "2.0.0"
 
-graphql@^0.12.3:
-  version "0.12.3"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.12.3.tgz#11668458bbe28261c0dcb6e265f515ba79f6ce07"
+graphql@^0.13.0:
+  version "0.13.2"
+  resolved "http://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
   dependencies:
-    iterall "1.1.3"
+    iterall "^1.2.1"
 
 growl@1.10.3:
   version "1.10.3"
@@ -2025,9 +2025,9 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-iterall@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.3.tgz#1cbbff96204056dde6656e2ed2e2226d0e6d72c9"
+iterall@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1455,9 +1455,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@0.62.0:
-  version "0.62.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.62.0.tgz#14bca669a6e3f95c0bc0c2d1eb55ec4e98cb1d83"
+flow-bin@0.68.0:
+  version "0.68.0"
+  resolved "http://registry.npmjs.org/flow-bin/-/flow-bin-0.68.0.tgz#86c2d14857d306eb2e85e274f2eebf543564f623"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
@AGS- Hey, I took a stab at fixing the test failures you were seeing in #252.

It looks like there were just two issues that needed resolving.

One: `graphql/languages/kinds` imports were deprecated.  I rewrote these as top level imports from `graphql` instead.

Two: `graphql@0.13.2` uses `flow@0.68.0`.  Because this package is so tightly coupled to `graphql`, I think it's useful to keep the typechecking in sync.  I upgraded flow, and only had to resolve one error, to keep things working.  👍 