### PR TITLE
graphql-language-service-utils: remove incompatible peer dependencies

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -26,7 +26,7 @@
     "prepublish": "node ../../resources/prepublish.js"
   },
   "peerDependencies": {
-    "graphql": "^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0"
+    "graphql": "^0.12.0 || ^0.13.0"
   },
   "dependencies": {
     "graphql-config": "2.0.1",


### PR DESCRIPTION
Drop support for graphql v0.10 and v0.11 as these versions do not contain `ExecutableDefinitions` (required by packages/utils/src/validateWithCustomRules.js)

N.b. this will require a major version bump at the next release.

Fixes #239